### PR TITLE
[0.11.0] - 2026-04-02

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 # CHANGELOG
 
 
+## [0.11.0] - 2026-04-02
+### Added
+- upwork-analysis/app-comparison-march-2026.md
+- upwork-analysis/high-paying-guide-march-2026.md
+- upwork_export_filtered_2026-03.csv
+- MARCH_2026_SKOOL_POST.md (Skool.com community post)
+### Changed
+- upwork-analysis/upwork-analysis.html: Updated to include March 2026 data (May 2025-March 2026, 11-month analysis, 50,141 total jobs)
+### Key Findings
+- Spring bounce: 3,939 jobs (+6.7% MoM)—strongest growth since summer, first time all three platforms grew since July 2025
+- Rate correction: $40.67/hr (-6.0% from February's $43.27 peak)—third-highest ever, structural floor above $40
+- GoHighLevel all-time high: 693 jobs (+18.5% MoM, +23.5% since May)—highest single-month CRM count since tracking began
+- n8n decline broken: +4.3% MoM after three months of accelerating losses (-3.8%, -7.7%, -8.6%), total growth rebounds to +11.0%
+- Make.com recovery confirmed: +8.1% MoM, second consecutive positive month (803 jobs)
+- HubSpot surges: +7.4% MoM, +12.3% since May—strongest since August
+- QuickBooks strongest total growth: +30.6% since May (94 jobs)—top application by total growth
+- Generic CRM mentions all-time high: 1,434 (+19.3% since May)—CRM demand expanding
+- AI voice agents emerge: $150-250/hr new premium niche (Retell, Vapi platforms)
+- Market equilibrium: ~3,900-4,000 jobs at $40-42/hr may be the new normal
+
+
 ## [0.10.0] - 2026-03-02
 ### Added
 - upwork-analysis/app-comparison-february-2026.md

--- a/upwork-analysis/app-comparison-march-2026.md
+++ b/upwork-analysis/app-comparison-march-2026.md
@@ -1,0 +1,322 @@
+# Upwork Automation Market: Platform & Application Comparison
+## March 2026 Analysis
+
+**Report Date:** April 2026
+**Data Period:** May 2025 - March 2026 (11 months)
+**Total Jobs Analyzed:** 50,141
+
+---
+
+## Executive Summary
+
+March 2026 delivered the spring bounce the market needed. Volume rebounded to 3,939 jobs (+6.7% MoM), the strongest monthly growth since summer 2025 and the first time all three major platforms grew simultaneously since July 2025. After February's tracking low of 3,690, the market is back near January's 3,945 level.
+
+The headline stories: **GoHighLevel surged +18.5% to 693 jobs**—the highest single-month count for any CRM since tracking began. **n8n broke its three-month accelerating decline** with +4.3% growth, rebounding total growth since May to +11.0%. **Make.com posted its second consecutive positive month** (+8.1%), confirming the recovery trend. **Rates corrected to $40.67/hr** (-6.0% from February's $43.27 peak), still the third-highest rate ever recorded and above January's $40.20.
+
+**Key March Insight:** The volume-rate trade-off is clear—more work available at slightly lower average rates. The market may be finding equilibrium around 3,900-4,000 jobs at $40-41/hr, a structurally better market than the $37-39 range that prevailed from May through December.
+
+---
+
+## Platform Comparison: Eleven-Month Evolution
+
+### Major Automation Platforms
+
+| Platform | May | June | July | Aug | Sept | Oct | Nov | Dec | Jan | Feb | Mar | Feb MoM | Total Growth |
+|----------|-----|------|------|-----|------|-----|-----|-----|-----|-----|-----|---------|--------------|
+| **Zapier** | 2,236 | 2,554 | 2,796 | 2,663 | 2,233 | 2,132 | 1,662 | 1,753 | 1,767 | 1,721 | 1,826 | 🟢 +6.1% | 📉 -18.3% |
+| **n8n** | 1,319 | 1,794 | 1,984 | 2,155 | 2,099 | 2,024 | 1,729 | 1,663 | 1,535 | 1,403 | 1,464 | 🟢 +4.3% | 🚀 +11.0% |
+| **Make.com** | 1,143 | 1,278 | 1,429 | 1,174 | 967 | 1,027 | 811 | 751 | 725 | 743 | 803 | 🟢 +8.1% | 📉 -29.7% |
+| **Power Automate** | 29 | 30 | 28 | 47 | 33 | 42 | 20 | 28 | 37 | 22 | 29 | 🚀 +31.8% | 🟢 0.0% |
+
+**Status Indicators:**
+- 🚀 Strong Growth (>10%)
+- 🟢 Stable/Growth (0-10%)
+- 🟡 Slight Decline (0-5%)
+- 📉 Declining (>5%)
+- 💥 Collapse (>20%)
+
+### Platform Analysis
+
+**Zapier (Steady Leader)**
+- Current: 1,826 jobs (46.4% market share)
+- Trend: +6.1% MoM, strong rebound from February's -2.6%
+- Total: Down -18.3% since May, but highest absolute count since December
+- Assessment: Maintains market dominance with consistent resilience
+- Recommendation: Primary platform choice remains unchanged
+
+**n8n (Decline Broken)**
+- Current: 1,464 jobs (37.2% market share)
+- Trend: +4.3% MoM, **breaking three months of accelerating decline** (-3.8%, -7.7%, -8.6%)
+- Total: +11.0% since May, rebounding from February's +6.4%
+- Assessment: The decline trajectory feared in February did not materialize
+- Recommendation: Premium positioning reaffirmed; trajectory now positive
+
+**Make.com (Recovery Confirmed)**
+- Current: 803 jobs (20.4% market share)
+- Trend: +8.1% MoM, **second consecutive positive month**
+- Total: Down -29.7% since May (improved from -35.0% in February)
+- Assessment: Recovery confirmed after two consecutive growth months
+- Recommendation: Viable secondary platform; still not primary-only material
+
+**Power Automate (Small but Rebounded)**
+- Current: 29 jobs
+- Trend: +31.8% MoM, back to May baseline
+- Total: Flat (0.0% since May)
+- Assessment: Too small for standalone specialization
+- Recommendation: Enterprise Microsoft ecosystem only
+
+---
+
+## Application Ecosystem: March 2026
+
+### Top 15 Applications by Job Volume
+
+| Application | May | June | July | Aug | Sept | Oct | Nov | Dec | Jan | Feb | Mar | Feb MoM | Total | Status |
+|-------------|-----|------|------|-----|------|-----|-----|-----|-----|-----|-----|---------|-------|--------|
+| **GoHighLevel** | 561 | 647 | 682 | 647 | 662 | 659 | 579 | 562 | 645 | 585 | 693 | 🚀 +18.5% | 🚀 +23.5% | **All-time high** |
+| **Google Sheets** | 786 | 931 | 984 | 815 | 719 | 726 | 597 | 552 | 537 | 495 | 527 | 🟢 +6.5% | 📉 -33.0% | Bounce |
+| **Airtable** | 666 | 779 | 916 | 731 | 604 | 611 | 505 | 492 | 467 | 424 | 435 | 🟢 +2.6% | 📉 -34.7% | Slight bounce |
+| **HubSpot** | 334 | 396 | 412 | 490 | 450 | 447 | 346 | 333 | 350 | 349 | 375 | 🟢 +7.4% | 🚀 +12.3% | **Strong growth** |
+| **Slack** | 482 | 485 | 625 | 519 | 460 | 461 | 354 | 321 | 307 | 316 | 335 | 🟢 +6.0% | 📉 -30.5% | Bounce |
+| **Excel** | 494 | 564 | 602 | 626 | 549 | 568 | 403 | 382 | 316 | 280 | 251 | 📉 -10.4% | 📉 -49.2% | Accelerating decline |
+| **Notion** | 433 | 537 | 592 | 483 | 325 | 414 | 321 | 341 | 273 | 243 | 229 | 📉 -5.8% | 📉 -47.1% | Continued decline |
+| **Monday.com** | 108 | 133 | 141 | 125 | 98 | 97 | 101 | 90 | 102 | 101 | 104 | 🟢 +3.0% | 🟡 -3.7% | Stable |
+| **ClickUp** | 195 | 186 | 251 | 199 | 166 | 182 | 135 | 169 | 146 | 134 | 116 | 📉 -13.4% | 📉 -40.5% | Steep decline |
+| **Zoho** | 103 | 113 | 175 | 163 | 124 | 141 | 128 | 122 | 82 | 120 | 101 | 📉 -15.8% | 🟡 -1.9% | Pullback |
+| **Salesforce** | 87 | 121 | 110 | 146 | 149 | 106 | 81 | 96 | 88 | 110 | 88 | 💥 -20.0% | 🟢 +1.1% | Post-surge correction |
+| **QuickBooks** | 72 | 112 | 108 | 123 | 93 | 95 | 79 | 64 | 77 | 73 | 94 | 🚀 +28.8% | 🚀 +30.6% | **Strongest total growth** |
+| **Asana** | 80 | 99 | 92 | 100 | 93 | 97 | 67 | 71 | 64 | 65 | 49 | 💥 -24.6% | 📉 -38.8% | Sharp decline |
+| **Xero** | 35 | 44 | 60 | 58 | 43 | 51 | 40 | 34 | 30 | 37 | 43 | 🚀 +16.2% | 🚀 +22.9% | Q1 accounting |
+| **Trello** | 75 | 87 | 94 | 78 | 75 | 55 | 48 | 47 | 26 | 24 | 31 | 🚀 +29.2% | 💥 -58.7% | Minor bounce |
+
+---
+
+## CRM Platform Deep Dive
+
+### Dedicated CRM Systems
+
+| CRM | May | February | March | Feb→Mar | Total Growth | Market Assessment |
+|-----|-----|----------|-------|---------|--------------|-------------------|
+| **GoHighLevel** | 561 | 585 | 693 | +18.5% | +23.5% | **All-time high, dominant CRM by volume** |
+| **HubSpot** | 334 | 349 | 375 | +7.4% | +12.3% | **Strongest since August, double-digit total growth** |
+| **Salesforce** | 87 | 110 | 88 | -20.0% | +1.1% | Post-February correction, barely positive |
+| **Zoho** | 103 | 120 | 101 | -15.8% | -1.9% | Pulled back, first negative total since tracking |
+
+**Key Insight:** The CRM rotation continues its pendulum swing. February's winners (Salesforce +25.0%, Zoho +46.3%) became March's losers (Salesforce -20.0%, Zoho -15.8%). Meanwhile, February's losers (GoHighLevel -9.3%) became March's stars (GoHighLevel +18.5%). GoHighLevel at 693 jobs is the highest monthly count for any CRM since tracking began. HubSpot's +7.4% is its strongest month since the July-August growth phase. Three of four CRMs remain positive since May, with Zoho barely dipping negative (-1.9%).
+
+### Generic "CRM" Mentions
+
+| Month | Mentions | Change |
+|-------|----------|--------|
+| May | 1,202 | Baseline |
+| February | 1,241 | +0.2% MoM |
+| March | 1,434 | +15.6% MoM |
+
+Generic CRM mentions surged +15.6% to 1,434—the highest since tracking began and +19.3% above May baseline. CRM demand is not just resilient, it's expanding.
+
+### Alternative CRM Solutions
+
+| Application | May | March | Change | Assessment |
+|-------------|-----|-------|--------|------------|
+| **Airtable** | 666 | 435 | -34.7% | Slight bounce but structural decline |
+| **Notion** | 433 | 229 | -47.1% | Continued erosion |
+| **ClickUp** | 195 | 116 | -40.5% | Accelerating decline |
+| **Monday.com** | 108 | 104 | -3.7% | Most stable alternative |
+
+**Combined Alternative CRMs:** 780 jobs (March) vs 1,294 jobs (May) = -39.7%
+
+**Insight:** Alternative CRM tools declining roughly twice as fast as dedicated CRMs. The gap continues to widen. Monday.com's stability (-3.7% total) remains the standout among alternatives.
+
+---
+
+## March Market Dynamics
+
+### Volume Rebounds from Tracking Low
+
+**Volume Trends:**
+- July Peak: 5,522 jobs
+- February: 3,690 jobs (tracking low, -33.2% from peak)
+- March: 3,939 jobs (+6.7% MoM, **-28.7% from peak**)
+
+**Assessment:** The spring bounce is real. March's +6.7% is the strongest monthly growth since summer 2025. All three major platforms grew simultaneously for the first time since July 2025. The market may be finding equilibrium in the 3,900-4,000 range.
+
+### Rate Correction from Peak
+
+| Month | Avg Rate | High-Paying Count ($75+) | Premium Share | Trend |
+|-------|----------|--------------------------|---------------|-------|
+| May | $39.10/hr | 153 | 3.6% | Baseline |
+| July | $39.61/hr | 214 | 3.9% | Peak volume |
+| December | $37.58/hr | 144 | 3.7% | Rate trough |
+| January | $40.20/hr | 165 | 4.2% | First all-time high |
+| February | $43.27/hr | 170 | 4.6% | Second all-time high |
+| March | $40.67/hr | 167 | 4.2% | **Correction from peak** |
+
+**Analysis:** Rates corrected -6.0% from February's $43.27 surge to $40.67. This was expected—two months of 7%+ growth was unsustainable. But $40.67 is still the third-highest rate ever recorded, above January's $40.20 and well above the $37-39 range from May through December. The structural shift above $40/hr appears genuine.
+
+### Platform Leadership
+
+**All Three Platforms Grew**
+
+| Platform | February | March | Share Change |
+|----------|----------|-------|-------------|
+| Zapier | 1,721 (46.6%) | 1,826 (46.4%) | -0.2 pts |
+| n8n | 1,403 (38.0%) | 1,464 (37.2%) | -0.8 pts |
+| Make.com | 743 (20.1%) | 803 (20.4%) | +0.3 pts |
+
+All three platforms grew in March, but at different rates. Make.com's +8.1% was the strongest, gaining 0.3 share points. Zapier maintained its dominant position at 46.4%. n8n's +4.3% was enough to break the decline trend but not enough to prevent slight share loss.
+
+### March Winners and Losers
+
+**Applications with March MoM Growth:**
+- Trello: +29.2% (31 jobs)—minor bounce from near-extinction, still -58.7% total
+- QuickBooks: +28.8% (94 jobs)—Q1 accounting surge, +30.6% since May
+- GoHighLevel: +18.5% (693 jobs)—all-time high, agency demand strong
+- Xero: +16.2% (43 jobs)—Q1 accounting demand
+- HubSpot: +7.4% (375 jobs)—strongest since August
+- Google Sheets: +6.5% (527 jobs)—rebound from multi-month decline
+- Slack: +6.0% (335 jobs)—continued recovery
+- Monday.com: +3.0% (104 jobs)—stable
+- Airtable: +2.6% (435 jobs)—slight bounce
+
+**Applications with March Declines:**
+- Asana: -24.6% (49 jobs)—sharp drop, -38.8% total
+- Salesforce: -20.0% (88 jobs)—correction from February's +25.0% surge
+- Zoho: -15.8% (101 jobs)—pullback from February's +46.3% recovery
+- ClickUp: -13.4% (116 jobs)—continued structural decline
+- Excel: -10.4% (251 jobs)—continued commoditization
+- Notion: -5.8% (229 jobs)—continued erosion
+
+---
+
+## Strategic Recommendations
+
+### Platform Strategy for Q2 2026
+
+**1. Zapier: Consistent Leader**
+- 1,826 jobs (46.4% market share)
+- +6.1% rebound, highest count since December
+- Most stable platform across market cycles
+
+**Recommendation:** Primary platform for volume and stability
+
+**2. n8n: Decline Broken, Premium Intact**
+- 1,464 jobs (37.2% share), +11.0% since May
+- +4.3% after three months of steep decline
+- Technical depth still commands premium rates
+
+**Recommendation:** Premium positioning reaffirmed; dual-platform approach still wise
+
+**3. Make.com: Recovery Confirmed**
+- 803 jobs (20.4% share), two consecutive growth months (+2.5%, +8.1%)
+- -29.7% total still concerning
+- Trajectory clearly positive
+
+**Recommendation:** Viable secondary platform; reassess as primary if growth sustains through Q2
+
+**4. CRM Rotation: GoHighLevel and HubSpot Lead**
+- GoHighLevel +23.5% since May (693 jobs, all-time high)
+- HubSpot +12.3% since May (375 jobs, strongest since August)
+- Salesforce +1.1% since May (corrected from February surge)
+- Zoho -1.9% since May (barely negative, volatile)
+
+**Recommendation:** GoHighLevel for agencies, HubSpot for enterprise stability, Salesforce for premium enterprise
+
+### Application Strategy
+
+**High-Value Specializations:**
+
+1. **CRM + Automation Specialist** ($75-180/hr)
+   - GoHighLevel at all-time high, HubSpot surging, generic CRM mentions at record levels
+   - Three of four dedicated CRMs positive since May
+
+2. **Accounting Automation** ($60-120/hr)
+   - QuickBooks +30.6% since May (strongest total growth of any application)
+   - Xero +22.9% since May, consistent Q1 demand
+
+3. **AI-Enhanced Automation** ($120-250/hr)
+   - Rates still structurally above $40/hr
+   - AI capabilities continue to drive premium positioning
+
+4. **n8n Technical Specialist** ($80-150/hr)
+   - Decline broken, +11.0% since May
+   - Self-hosted and custom development commands premium
+
+**Avoid/Deprioritize:**
+- Excel-only: -49.2% since May (251 jobs)—worst performer, approaching half its May volume
+- Notion-only: -47.1% since May (229 jobs)—continued structural decline
+- ClickUp-only: -40.5% since May (116 jobs)—accelerating erosion
+- Trello: -58.7% since May (31 jobs)—despite minor bounce, still near-extinct
+- Platform-only generalist: CRM + platform combinations still essential
+
+### Rate Strategy for Q2 2026
+
+**Current Market:**
+- Average: $40.67/hr (corrected from February's $43.27, still third-highest ever)
+- High-paying jobs ($75+): 167 (4.2% of market)
+- Ultra-premium ($150+): 15 jobs
+- Max rate: $999/hr
+
+**Positioning:**
+- **Entry:** $25-40/hr (shrinking, avoid)
+- **Experienced:** $50-75/hr (296 jobs, requires specialization)
+- **Specialist:** $75-130/hr (CRM + platform + industry)
+- **Premium:** $130-250/hr (AI + technical depth + proven results)
+
+**Key:** February's $43.27 was a Q1 peak, but the structural floor has shifted above $40/hr. The market supports premium pricing for specialists.
+
+---
+
+## Q2 2026 Outlook
+
+### Expected April-June Trends
+
+1. **Volume stabilization:** March's 3,939 suggests equilibrium around 3,900-4,000 range
+2. **Rate normalization:** $40-42/hr likely sustainable, $43+ was a Q1 peak
+3. **GoHighLevel momentum:** 693 jobs may be a new baseline for agency CRM demand
+4. **n8n recovery:** If growth continues, the platform's premium position is secure
+5. **Make.com trajectory:** Third consecutive growth month would confirm structural recovery
+6. **CRM demand expanding:** Generic CRM mentions at all-time high (+19.3% since May)
+7. **Accounting surge:** QuickBooks and Xero Q1 demand may moderate but structural growth intact
+
+### Market Structure Evolution
+
+**What's Happened (11 months):**
+- Market contracted -28.7% from July peak, then bounced
+- Average rates structurally above $40/hr (up from $37-39 range)
+- CRM demand outperforms all other categories
+- All three platforms showing simultaneous growth
+- Premium market stable at 4.2% share (167 jobs at $75+)
+
+**What's Next:**
+- Market equilibrium likely around 3,800-4,100 monthly jobs
+- Rates stabilizing in $40-42/hr range
+- GoHighLevel and HubSpot leading CRM demand
+- AI capabilities remain premium differentiator
+- Volume-rate trade-off: more jobs at slightly lower rates vs. fewer at higher rates
+
+---
+
+## Methodology
+
+**Data Source:** Upwork job export CSVs (May 2025-March 2026)
+**Analysis Method:** Keyword search in job titles and descriptions (substring matching)
+**Platform Keywords:** "Zapier", "Make.com"/"Integromat", "n8n", "Power Automate"
+**Application Keywords:** Specific product names in job descriptions
+**Rate Calculation:** Average of hourly maximum rates where provided
+
+**Limitations:**
+- Jobs may mention multiple platforms (overlap exists)
+- Generic automation jobs without platform mentions excluded
+- Rates are posted maximums, not actual contracted rates
+- Sample represents Upwork marketplace only
+- Substring matching may catch incidental mentions (e.g., "excel" in "excellent")
+
+---
+
+**Report Generated:** April 2026
+**Next Update:** April 2026 data (expected May 2026)
+**Questions/Feedback:** Via GitHub Issues
+
+---
+
+*This analysis is part of the ongoing Upwork Automation Market Analysis project tracking the evolution of the automation consulting marketplace.*

--- a/upwork-analysis/high-paying-guide-march-2026.md
+++ b/upwork-analysis/high-paying-guide-march-2026.md
@@ -1,0 +1,628 @@
+# High-Paying Automation Opportunities Guide
+## March 2026 Market Analysis
+
+**Report Date:** April 2026
+**Data Period:** May 2025 - March 2026
+**High-Paying Jobs Tracked:** 167 jobs at $75+/hr in March
+
+---
+
+## Executive Summary
+
+March 2026 delivered a volume rebound with a rate correction—the classic market trade-off. **High-paying opportunities held at 167 jobs at $75+/hr** (down slightly from February's 170), representing 4.2% of total market. Average rates corrected to $40.67/hr (-6.0% from February's $43.27 peak) but remain the third-highest rate ever recorded, above January's $40.20.
+
+The market expanded +6.7% to 3,939 jobs, with all three major platforms growing simultaneously for the first time since July 2025. Ultra-premium roles ($150+/hr) contracted to 15 jobs (from 29 in February), while the expert tier ($75-100/hr) expanded to 95 jobs (from 82). The premium market is redistributing toward the $75-100 range rather than disappearing.
+
+**Bottom Line:** February's rate spike was a Q1 peak, not a new floor. But the structural shift above $40/hr is real. The premium market remains healthy, and the volume rebound means more total opportunity for specialists.
+
+---
+
+## Rate Tiers & Market Reality
+
+### March 2026 Rate Breakdown
+
+| Tier | Rate Range | Jobs Available | Requirements | Market Trend |
+|------|------------|----------------|--------------|--------------|
+| **Ultra-Premium** | $150-250/hr | ~15 jobs | AI + platform mastery + industry | Contracted from Feb peak |
+| **Premium** | $100-150/hr | ~57 jobs | Multi-platform + specialized niche | Stable |
+| **Expert** | $75-100/hr | ~95 jobs | Platform certified + proven results | **Expanded** |
+| **Experienced** | $50-75/hr | ~296 jobs | Multi-platform competency | Strong |
+| **Mid-Tier** | $40-50/hr | ~256 jobs | Single platform proficiency | Compressing |
+| **Entry** | $25-40/hr | ~422 jobs | Basic automation tasks | Disappearing |
+
+**Key Insight:** The premium market redistributed in March. Ultra-premium ($150+) contracted from 29 to 15 jobs, but the expert tier ($75-100) expanded from 82 to 95 jobs. Total premium ($75+) held at 167 (vs 170 in Feb). The premium market is shifting toward more accessible entry points rather than concentrating at the top.
+
+### Average Rate Evolution
+
+| Month | Market Average | High-Paying Count ($75+) | Premium Share | Trend |
+|-------|----------------|--------------------------|---------------|-------|
+| May | $39.10/hr | 153 | 3.6% | Baseline |
+| July | $39.61/hr | 214 | 3.9% | Peak volume |
+| November | $38.79/hr | 139 | 3.3% | Trough |
+| December | $37.58/hr | 144 | 3.7% | Rate floor |
+| January | $40.20/hr | 165 | 4.2% | First all-time high |
+| February | $43.27/hr | 170 | 4.6% | Second all-time high |
+| March | $40.67/hr | 167 | 4.2% | **Correction from peak** |
+
+**Analysis:** The rate correction was expected—February's 7.6% surge on top of January's 7.0% was unsustainable. March's $40.67 is a healthy landing: still above $40 (which the market had never sustained before January), and above the $37-39 range from May-December. The structural rate floor has shifted upward even as volume rebounds.
+
+---
+
+## Ultra-Premium Opportunities ($150-250/hr)
+
+### Profile Requirements
+
+**Technical Stack:**
+- Zapier (46.4% market share) OR n8n (technical depth, recovery confirmed)
+- AI/LLM integration (OpenAI, Anthropic APIs)
+- Voice AI (Retell, Vapi—emerging premium category)
+- Custom development (Python, Node.js, TypeScript)
+- Self-hosted infrastructure (Docker, Kubernetes)
+
+**Industry Knowledge:**
+- Real estate (AI voice agents, CRM automation)
+- Financial services (fintech, compliance)
+- Healthcare (HIPAA, patient workflows)
+- Construction/trades (AI receptionist, scheduling)
+- E-commerce (subscription management, tracking)
+
+**Proven Track Record:**
+- Portfolio of $75K+ projects
+- Verifiable ROI metrics
+- Industry-specific case studies
+- Technical certifications
+- Published thought leadership
+
+### March Market Reality
+
+Ultra-premium opportunities contracted to ~15 jobs (from 29 in February). This is a return to more typical levels after February's Q1 budget-driven expansion. These roles are:
+- AI voice agent development ($150-250/hr)—Retell, Vapi integration
+- CRM architecture and RevOps consulting ($150-210/hr)
+- Enterprise integration projects ($150-200/hr)
+- AI coaching and strategic consulting ($130-250/hr)
+
+**Entry Barrier:** Very high—requires 3+ years specialized experience, multiple technical certifications, and documented enterprise results.
+
+### Actual March Examples
+
+**Example 1: AI Voice Agent Expert (Retell/Vapi)**
+- Rate: $250/hr
+- Requirements: Production-grade AI voice agents, Retell platform, conversational AI
+- Project: Coaching/consulting for setting up conversational flow agents
+- Context: Emerging premium category—AI voice automation for service businesses
+
+**Example 2: CRM Selection Consultant / RevOps Expert**
+- Rate: $210/hr
+- Requirements: CRM architecture expertise, RevOps strategy, multi-system evaluation
+- Project: CRM platform selection and implementation roadmap
+- Context: Generic CRM mentions at all-time high—demand for strategic CRM guidance surging
+
+**Example 3: Affiliate Tracking Expert (n8n + Everflow)**
+- Rate: $200/hr
+- Requirements: n8n + affiliate marketing platforms + tracking architecture
+- Project: Insurance comparison platform tracking and attribution
+- Context: n8n recovery (+4.3%) driving technical platform demand
+
+**Example 4: HubSpot Specialist (Luxury Retail)**
+- Rate: $200/hr
+- Requirements: HubSpot expertise, luxury retail industry knowledge
+- Project: CRM implementation for European luxury watch dealer
+- Context: HubSpot surging +7.4%, industry-specific expertise commands premium
+
+---
+
+## Premium Opportunities ($100-150/hr)
+
+### Profile Requirements
+
+**Core Competencies:**
+- Deep expertise in one platform + working knowledge of second
+- CRM specialization (GoHighLevel at all-time high, HubSpot surging)
+- AI integration capabilities (API implementation, prompt engineering)
+- Strategic consulting (beyond just implementation)
+- Industry-specific positioning
+
+**Differentiators:**
+- Published case studies with ROI metrics
+- Platform certifications (n8n, HubSpot, Zapier, Salesforce)
+- Content marketing (blog, YouTube, LinkedIn)
+- Proprietary frameworks or templates
+- Strong client references
+
+### March High-Demand Segments
+
+#### 1. GoHighLevel Agency Automation ($100-150/hr)
+
+**Opportunity:** 693 jobs—all-time high, surging +18.5% MoM, +23.5% since May
+
+**Skills Needed:**
+- GoHighLevel platform mastery (workflows, CRM, funnels)
+- n8n or Zapier for external integrations
+- Marketing automation and funnel optimization
+- White-label solution development
+- Agency workflow consulting
+
+**Why Premium:** GoHighLevel posted its highest monthly count in 11 months of tracking. Agency demand for automation is at peak levels. Q1 budget cycles driving sustained investment.
+
+**March Insight:** GoHighLevel at 693 jobs is unambiguously the dominant CRM by volume and growth trajectory.
+
+#### 2. AI Voice Agent Development ($130-250/hr)
+
+**Opportunity:** Emerging premium category across construction, services, real estate
+
+**Skills Needed:**
+- Retell or Vapi platform expertise
+- AI/LLM API integration
+- Telephony systems and low-latency optimization
+- Industry-specific conversation design
+- n8n or Zapier for backend workflows
+
+**Why Premium:** Multiple $150+ roles specifically for AI voice agents in March. Construction, HVAC, plumbing, and real estate businesses adopting AI receptionists. This is a new premium niche.
+
+#### 3. n8n Technical Specialist ($100-150/hr)
+
+**Opportunity:** 1,464 jobs—decline broken, +4.3% MoM, +11.0% since May
+
+**Skills Needed:**
+- n8n self-hosting (Docker, custom nodes)
+- Claude/GPT API integration with n8n
+- Complex workflow architecture
+- AI agent and coaching implementations
+- Custom automation consulting
+
+**Why Premium:** n8n's recovery reaffirms its premium position. Multiple $125-150/hr coaching and consulting roles for n8n + AI combinations.
+
+**March Insight:** n8n breaking its three-month decline validates continued investment in the platform.
+
+#### 4. CRM + Platform Specialist ($100-150/hr)
+
+**Opportunity:** Generic CRM mentions at all-time high (1,434), three of four CRMs positive since May
+
+**Skills Needed:**
+- Deep expertise in one CRM (GoHighLevel, HubSpot, Salesforce, or Zoho)
+- Zapier or n8n proficiency for integrations
+- Migration and data quality expertise
+- Industry-specific CRM configuration
+- Multi-system orchestration
+
+**Why Premium:** CRM demand expanding—generic "CRM" mentions +19.3% since May. Businesses actively seeking CRM automation expertise.
+
+---
+
+## Expert Tier Opportunities ($75-100/hr)
+
+### Profile Requirements
+
+**Core Skills:**
+- Deep expertise in one platform (Zapier or n8n) OR
+- Solid competency in two platforms
+- Proven delivery track record (50+ projects)
+- Industry-specific knowledge
+- Project management capabilities
+
+**Minimum Credentials:**
+- 100+ completed automations
+- 10+ client references
+- Platform certification
+- Public portfolio with case studies
+
+### Resilient Segments
+
+#### 1. Accounting Automation ($75-100/hr)
+
+**Opportunity:** QuickBooks (94 jobs, +30.6% since May), Xero (43 jobs, +22.9% since May)
+
+**Focus:**
+- QuickBooks + Zapier/Make.com integration
+- Xero automation workflows
+- Financial reporting automation
+- Invoice and payment processing
+- Tax season workflow optimization
+
+**Why Growing:** QuickBooks has the strongest total growth (+30.6%) of any tracked application. Accounting automation delivers measurable ROI and Q1 tax season drives consistent demand.
+
+#### 2. Multi-CRM Integration ($75-100/hr)
+
+**Opportunity:** CRM demand at record levels, three of four dedicated CRMs positive
+
+**Focus:**
+- HubSpot + Salesforce synchronization
+- CRM migration projects (legacy to modern)
+- Multi-system data flows
+- Duplicate prevention and data quality
+
+**Why Stable:** GoHighLevel and HubSpot both surging. Companies continue consolidating and migrating CRM systems.
+
+#### 3. E-Commerce Automation ($75-95/hr)
+
+**Opportunity:** Shopify + subscription management showing strong demand
+
+**Focus:**
+- Shopify + automation platforms
+- Subscription management (Recharge)
+- Inventory and fulfillment workflows
+- Customer lifecycle automation
+- Multi-channel synchronization
+
+**Why Stable:** Subscription-based businesses need automation for growth. March showed $150/hr Recharge/Shopify specialist roles.
+
+#### 4. Zapier Advanced Implementation ($75-100/hr)
+
+**Opportunity:** 1,826 jobs—Zapier at highest count since December, 46.4% market share
+
+**Focus:**
+- Zapier Tables and Interfaces
+- Complex multi-step workflows
+- Error handling and monitoring
+- Zapier for Teams deployment
+- Migration from legacy tools
+
+**Why Relevant:** Zapier's rebound (+6.1%) and dominant market share mean consistent opportunity for advanced implementation work.
+
+---
+
+## Capitalizing on the Volume Rebound
+
+### March Market Reality
+
+**Market Status:**
+- Total jobs: 3,939 (+6.7% MoM—rebound from tracking low)
+- Average rate: $40.67/hr (corrected from February peak, still third-highest ever)
+- High-paying jobs: 167 (-1.8% from February, 4.2% share)
+- Ultra-premium ($150+): 15 jobs (contracted from 29)
+- Expert tier ($75-100): 95 jobs (expanded from 82)
+- Max rate: $999/hr
+
+**What This Means:**
+- More total opportunity available (249 more jobs than February)
+- Rate correction was expected after two months of 7%+ growth
+- Structural floor above $40/hr appears to be holding
+- Premium market redistributing toward $75-100 tier (more accessible)
+- All three platforms growing—broadest opportunity in months
+
+### The Volume-Rate Trade-Off
+
+**February vs. March:**
+- February: 3,690 jobs at $43.27/hr = fewer opportunities, higher average pay
+- March: 3,939 jobs at $40.67/hr = more opportunities, slightly lower average pay
+
+**Implication:** The market is finding equilibrium. More work available, still at premium rates relative to the May-December $37-39 range. For consultants, this means more total opportunity even if individual average rates moderated.
+
+### The New Market Structure
+
+**Growing (~35% of market):**
+- CRM + platform specialists ($75-180/hr)
+- AI voice agent development ($130-250/hr)
+- GoHighLevel agency automation ($100-150/hr)
+- Accounting automation ($75-100/hr)
+
+**Stable (~30% of market):**
+- Advanced platform work ($60-100/hr)
+- Multi-platform expertise ($75-130/hr)
+- HubSpot implementations
+- Industry-specific positioning
+
+**Disappearing (~35% of market):**
+- Simple automation tasks (<$40/hr)
+- Single-platform generalists
+- Excel/Notion-only specialists
+- Competing on price vs. value
+
+### Action Plan
+
+#### If Revenue Growing: Maintain Momentum
+
+**Immediate:**
+1. Rates at $40.67 average still support premium pricing—hold rates steady
+2. Volume rebound means more opportunities to pursue selectively
+3. GoHighLevel at all-time high—add if not already in stack
+4. AI voice agents emerging as new premium niche
+5. Build retainer relationships with Q1 clients
+
+**Q2 Strategy:**
+1. Expand into AI voice agent development (Retell/Vapi)
+2. Deepen CRM expertise (GoHighLevel or HubSpot)
+3. Create case studies from Q1 premium work
+4. Position for sustained Q2 demand
+
+#### If Revenue Stable: Optimize Positioning
+
+**Actions:**
+1. Add CRM specialization if not already (GoHighLevel surging, HubSpot strong)
+2. Volume rebound means more accessible opportunities—increase proposal volume
+3. Develop AI integration capabilities for premium positioning
+4. Target $75+/hr engagements
+
+**Goal:** Capitalize on volume rebound while maintaining rate discipline
+
+#### If Revenue Down: Volume Creates Opportunity
+
+**Immediate:**
+1. More jobs available (+6.7%)—increase proposal activity
+2. All three platforms growing—broaden platform positioning
+3. Add accounting automation (QuickBooks surging +30.6% since May)
+4. Complete CRM certification (GoHighLevel or HubSpot)
+
+**30-Day Plan:**
+1. Complete CRM certification
+2. Build 2 AI-enhanced automation demos
+3. Target 20+ proposals per week to capitalize on volume rebound
+4. Apply to $60-80/hr range (market supports it)
+
+---
+
+## Rate Optimization Strategies
+
+### 1. Lead with CRM Expertise
+
+**Strategy:** CRM as primary differentiator—generic CRM mentions at all-time high
+
+**Before:** "I build Zapier/n8n automations"
+**After:** "I implement CRM automation that drives revenue and eliminates manual work"
+
+**Tactics:**
+- GoHighLevel for agencies (693 jobs, all-time high)
+- HubSpot for enterprise marketing (375 jobs, surging)
+- Salesforce for enterprise premium (88 jobs, still +1.1% since May)
+- Multi-CRM migration projects
+
+**Rate Impact:** +40-50% for CRM specialization
+
+### 2. AI Voice Agent Positioning
+
+**Strategy:** AI voice agents are the newest premium niche—$150-250/hr opportunities
+
+**Before:** "AI integration specialist"
+**After:** "AI voice automation expert—I build intelligent receptionists and agents"
+
+**Tactics:**
+- Retell or Vapi platform expertise
+- Industry-specific voice agent design (construction, real estate, services)
+- Low-latency optimization
+- Integration with CRM and scheduling systems
+
+**Rate Impact:** New premium tier, $130-250/hr
+
+### 3. Value-Based Pricing
+
+**Strategy:** Fixed-price packages based on business outcomes
+
+**Package Examples:**
+- "GoHighLevel Agency Setup: $12,000" (full CRM + automation + funnels)
+- "AI Voice Receptionist: $15,000" (24/7 AI phone handling)
+- "CRM Migration & Automation: $25,000" (eliminates manual work)
+- "Accounting Automation: $8,000" (QuickBooks + invoicing + reporting)
+
+**Benefits:**
+- Decouples rate from market pressure
+- Higher margins than hourly
+- Positions as strategic partner
+
+### 4. Retainer Model
+
+**Strategy:** Convert Q1 project clients to monthly recurring revenue
+
+**Retainer Tiers:**
+- **Maintenance:** $3,000-5,000/month (monitoring, updates, support)
+- **Optimization:** $5,000-12,000/month (continuous improvement, new workflows)
+- **Strategic:** $12,000-30,000/month (consultation, training, roadmap)
+
+**Benefits:**
+- Q1 project clients are ideal retainer candidates
+- Volume rebound means more potential retainer clients
+- Predictable revenue through Q2
+
+---
+
+## Platform Strategy for Q2 2026
+
+### March Landscape: All Platforms Growing
+
+**March Facts:**
+- Zapier: 1,826 jobs (46.4% share)—steady leader, +6.1%
+- n8n: 1,464 jobs (37.2% share)—decline broken, +4.3%
+- Make.com: 803 jobs (20.4% share)—recovery confirmed, +8.1%
+- First time all three grew simultaneously since July 2025
+
+**Strategic Implications:**
+
+**Zapier Positioning:**
+- Consistent market leader, 46.4% share
+- Most resilient across all market conditions
+- Broadest accessibility for mid-market clients
+- **Strategy:** Primary platform for volume and stability
+
+**n8n Positioning:**
+- Three-month decline broken with +4.3% growth
+- Total growth since May rebounds to +11.0%
+- Technical depth commands premium ($100-150+/hr)
+- **Strategy:** Premium positioning reaffirmed, confidence restored
+
+**Make.com Positioning:**
+- Second consecutive growth month (+2.5%, +8.1%)
+- Recovery confirmed—no longer just a possible floor
+- Still -29.7% total—not yet at sustainable levels
+- **Strategy:** Viable secondary platform, reassess if Q2 growth continues
+
+**Dual-Platform Approach:**
+- All three platforms growing—broadest opportunity set in months
+- 35-40% rate premium for multi-platform expertise
+- Platform-agnostic consulting increasingly valuable
+- Migration services between platforms remain in demand
+
+---
+
+## Application Strategy
+
+### Safe Bets (All Positive Since May)
+
+**1. GoHighLevel** (+23.5% since May)
+- 693 jobs—all-time high for any CRM
+- Agency automation demand at peak levels
+- Strongest monthly performance in tracking
+- **Positioning:** Agency CRM + automation specialist
+
+**2. QuickBooks** (+30.6% since May)
+- 94 jobs—strongest total growth of any tracked application
+- Q1 accounting demand driving surge
+- Measurable ROI, essential function
+- **Positioning:** Accounting automation specialist
+
+**3. HubSpot** (+12.3% since May)
+- 375 jobs—strongest since August, +7.4% MoM
+- Double-digit total growth, consistent demand
+- Certification commands premium
+- **Positioning:** Enterprise marketing automation
+
+**4. Xero** (+22.9% since May)
+- 43 jobs—small but consistently growing
+- Q1 accounting demand
+- Pairs well with QuickBooks expertise
+- **Positioning:** Accounting/finance automation niche
+
+### Watch List
+
+**Salesforce** (+1.1% since May)
+- 88 jobs—corrected from February's surge
+- Enterprise budgets may cycle back in Q2
+- **Watch:** April data for recovery
+
+**Monday.com** (-3.7% since May)
+- 104 jobs—remarkably stable
+- Most resilient alternative CRM
+- **Watch:** Continued stability
+
+### Avoid/Deprioritize
+
+**Structural Decline:**
+- Excel: -49.2% total (251 jobs)—approaching half of May volume
+- Notion: -47.1% total (229 jobs)—continued erosion
+- ClickUp: -40.5% total (116 jobs)—accelerating decline
+- Asana: -38.8% total (49 jobs)—sharp March drop
+- Trello: -58.7% total (31 jobs)—minor bounce doesn't change trajectory
+
+**Strategy:** Exit these specializations. Focus on CRM + platform + AI.
+
+---
+
+## Q2 2026 Outlook
+
+### Expected April-June Trends
+
+**April 2026:**
+- Volume likely stabilizes in 3,800-4,100 range
+- Rates expected to hold $40-42/hr range
+- GoHighLevel momentum likely continues
+- n8n recovery needs confirmation with continued growth
+
+**May-June 2026:**
+- Q2 project launches may sustain or slightly grow volume
+- Rate normalization around $40-42/hr (structurally higher than pre-January)
+- CRM demand remains primary growth driver
+- AI voice agents may emerge as measurable premium category
+
+**Q2 Bottom Line:**
+- New market reality: ~3,800-4,100 monthly jobs at $40-42/hr average
+- Premium market stable around 4.0-4.5% share
+- CRM specialization remains safest bet
+- AI capabilities (including voice agents) drive premium positioning
+
+---
+
+## Final Recommendations
+
+### The Premium Positioning Formula (Q2 2026)
+
+**1. CRM Foundation (Choose One):**
+- **GoHighLevel:** All-time high (693 jobs), agency focus, $100-150/hr
+- **HubSpot:** Surging +12.3%, enterprise stability, $90-140/hr
+- **Salesforce:** Corrected but still positive, enterprise premium, $100-180/hr
+- **QuickBooks/Xero:** Strongest total growth, accounting niche, $75-120/hr
+
+**2. Platform Proficiency:**
+- **Option A:** Zapier (market leader, 46.4% share, consistent)
+- **Option B:** n8n (decline broken, premium positioning, +11.0% since May)
+- **Option C:** Both (maximum flexibility, 35-40% rate premium)
+
+**3. AI Capabilities (Non-Negotiable):**
+- OpenAI or Anthropic API integration
+- Voice AI (Retell/Vapi)—emerging premium niche
+- Document processing and extraction
+- Intelligent routing and classification
+
+**4. Proof and Positioning:**
+- 3+ case studies with quantified ROI
+- Industry-specific portfolio
+- Thought leadership content
+- Value-based pricing model
+
+**Formula Result:** $100-200/hr sustainable rates, insulated from market volatility
+
+### The Bottom Line
+
+March 2026 proves the market is stabilizing—not at the bottom, but at a new equilibrium.
+
+**The numbers:**
+- 28.7% fewer jobs than July peak, but rebounding
+- $40.67/hr average—third highest ever, above the pre-January baseline
+- 167 premium jobs at $75+ (4.2% share)
+- All three platforms growing simultaneously
+- GoHighLevel at all-time high, HubSpot surging
+- Generic CRM mentions at record levels
+
+**Thriving Segments:**
+- CRM + platform specialists ($75-180/hr)
+- AI voice agent developers ($130-250/hr)
+- GoHighLevel agency automation (693 jobs, all-time high)
+- Accounting automation (QuickBooks +30.6% since May)
+- $75+/hr positioning (167 jobs, 4.2% share)
+
+**Struggling Segments:**
+- Platform-only generalists
+- No CRM specialization
+- No AI capabilities
+- Excel/Notion-only focus
+- <$50/hr positioning
+
+The volume rebound creates more opportunity. The rate correction was healthy. The structural shift above $40/hr is real. The specialist economy continues—with more jobs available than February.
+
+**More work. Still premium rates. CRM demand expanding. All platforms growing. Q2 is wide open.**
+
+---
+
+## Resources
+
+**Platform Mastery:**
+- n8n: Self-hosting guides, custom node development, Docker deployment
+- Zapier: Tables/Interfaces, advanced features, error handling
+- Make.com: Complex scenarios, error handling (recovery confirmed)
+
+**AI Integration:**
+- OpenAI API documentation and cookbook
+- Anthropic Claude API and prompt engineering
+- Retell/Vapi for AI voice agents (emerging premium)
+- LangChain for complex AI workflows
+
+**CRM Specialization:**
+- GoHighLevel: Certification program, community, templates (all-time high demand)
+- HubSpot: HubSpot Academy (free certification, surging demand)
+- Salesforce: Trailhead learning platform
+- QuickBooks: Integration certification (strongest total growth)
+
+**Business Skills:**
+- Value-based pricing frameworks
+- Case study development
+- Retainer model design
+- Thought leadership content
+
+---
+
+**Report Generated:** April 2026
+**Based on:** 50,141 jobs analyzed (May 2025-March 2026)
+**High-Paying Jobs Tracked:** 167 at $75+/hr in March (4.2% of market)
+**Next Update:** April 2026 data (expected May 2026)
+
+---
+
+*Part of the Upwork Automation Market Analysis Project*
+*Tracking the evolution of automation consulting opportunities*

--- a/upwork-analysis/upwork-analysis.html
+++ b/upwork-analysis/upwork-analysis.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Upwork Automation Market Analysis: May 2025-February 2026</title>
+    <title>Upwork Automation Market Analysis: May 2025-March 2026</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.js"></script>
     <style>
         * {
@@ -334,33 +334,33 @@
 
     <main>
         <section id="overview">
-            <h1>Upwork Automation Market Analysis: May 2025-February 2026</h1>
+            <h1>Upwork Automation Market Analysis: May 2025-March 2026</h1>
 
             <div class="market-alert">
-                <h4>📉 February 2026 Market Update: New Volume Low, Second Consecutive Rate Record</h4>
-                <p>The automation market hit a new tracking low in February 2026 at 3,690 jobs (-6.5% MoM), breaking January's brief stabilization. The market is now -33.2% from July's peak. But the rate story is extraordinary: <strong>rates surged to $43.27/hr</strong> (+7.6% MoM), a second consecutive all-time high. High-paying jobs rose to 170 (+3.0%), with premium share at 4.6%—the highest ever. Salesforce surged +25.0%, Zoho recovered +46.3%, while n8n's decline steepened to -8.6%. Fewer jobs, dramatically higher pay.</p>
+                <h4>📈 March 2026 Market Update: Spring Bounce, All Platforms Growing</h4>
+                <p>The automation market bounced back in March 2026 to 3,939 jobs (+6.7% MoM)—the strongest monthly growth since summer 2025. All three major platforms grew simultaneously for the first time since July 2025. Rates corrected to <strong>$40.67/hr</strong> (-6.0% from February's peak) but remain the third-highest ever recorded. GoHighLevel surged to an all-time high of 693 jobs (+18.5%). n8n broke its three-month accelerating decline with +4.3% growth. Make.com posted its second consecutive positive month (+8.1%).</p>
             </div>
 
             <div class="executive-summary">
                 <h3>Executive Summary</h3>
-                <p>February 2026 tells a compelling story: volume hit a new tracking low at 3,690 jobs (-6.5% MoM, -33.2% from July peak), while <strong>average rates surged to $43.27/hr</strong> (+7.6% MoM)—a second consecutive all-time high. Two months of 7%+ rate growth is unprecedented. High-paying jobs ($75+) rose to 170 (4.6% share, new record). Zapier held as the most resilient platform at 1,721 jobs (-2.6%, 46.6% share—highest ever). <strong>Salesforce surged +25.0%</strong> to 110 jobs (+26.4% since May), while Zoho recovered +46.3%. All four dedicated CRMs remain positive since May—CRM is the market's growth engine.</p>
+                <p>March 2026 delivered the spring bounce: volume rebounded to 3,939 jobs (+6.7% MoM, -28.7% from July peak), the strongest growth since summer 2025. Rates corrected to <strong>$40.67/hr</strong> (-6.0% from February's $43.27 peak)—still the third-highest ever, above January's $40.20. All three platforms grew for the first time since July 2025. <strong>GoHighLevel surged +18.5%</strong> to 693 jobs (all-time tracking high, +23.5% since May). <strong>n8n broke its decline</strong> at +4.3%, rebounding total growth to +11.0% since May. Generic CRM mentions hit an all-time high of 1,434 (+19.3% since May).</p>
 
                 <div class="key-insights">
-                    <h4>Critical February Developments:</h4>
+                    <h4>Critical March Developments:</h4>
                     <ul>
-                        <li><strong>New Tracking Low</strong>: 3,690 jobs (-6.5% MoM, -33.2% from July peak)</li>
-                        <li><strong>Second Rate Record</strong>: $43.27/hr average (+7.6% MoM)—two consecutive all-time highs</li>
-                        <li><strong>Premium Expansion</strong>: 170 high-paying jobs ($75+), 4.6% share—new record</li>
-                        <li><strong>Salesforce Surges</strong>: +25.0% MoM to 110 jobs (+26.4% since May)</li>
-                        <li><strong>n8n Accelerates Decline</strong>: -8.6% MoM, three consecutive months steepening</li>
-                        <li><strong>Zapier Dominates</strong>: 46.6% market share—highest ever, most resilient platform</li>
+                        <li><strong>Spring Bounce</strong>: 3,939 jobs (+6.7% MoM)—strongest growth since summer, all three platforms up</li>
+                        <li><strong>Rate Correction</strong>: $40.67/hr (-6.0% from Feb peak)—third-highest ever, structural floor above $40</li>
+                        <li><strong>GoHighLevel All-Time High</strong>: 693 jobs (+18.5% MoM, +23.5% since May)—dominant CRM</li>
+                        <li><strong>n8n Decline Broken</strong>: +4.3% MoM after three months of accelerating losses</li>
+                        <li><strong>Make.com Recovery Confirmed</strong>: +8.1% MoM, second consecutive positive month</li>
+                        <li><strong>CRM Demand Expanding</strong>: Generic CRM mentions at all-time high (1,434, +19.3% since May)</li>
                     </ul>
                 </div>
             </div>
         </section>
 
         <section id="platform-analysis">
-            <h2>Platform Analysis: Ten-Month Trends</h2>
+            <h2>Platform Analysis: Eleven-Month Trends</h2>
 
             <h3>Market Share & Growth Trajectory</h3>
             <table>
@@ -377,7 +377,8 @@
                         <th>December</th>
                         <th>January</th>
                         <th>February</th>
-                        <th>Jan&rarr;Feb</th>
+                        <th>March</th>
+                        <th>Feb&rarr;Mar</th>
                         <th>Total Growth</th>
                     </tr>
                 </thead>
@@ -394,8 +395,9 @@
                         <td>1,753</td>
                         <td>1,767</td>
                         <td>1,721</td>
-                        <td class="growth-negative">-2.6%</td>
-                        <td class="growth-negative">-23.0%</td>
+                        <td>1,826</td>
+                        <td class="growth-positive">+6.1%</td>
+                        <td class="growth-negative">-18.3%</td>
                     </tr>
                     <tr>
                         <td><strong>n8n</strong></td>
@@ -409,8 +411,9 @@
                         <td>1,663</td>
                         <td>1,535</td>
                         <td>1,403</td>
-                        <td class="growth-negative">-8.6%</td>
-                        <td class="growth-positive">+6.4%</td>
+                        <td>1,464</td>
+                        <td class="growth-positive">+4.3%</td>
+                        <td class="growth-positive">+11.0%</td>
                     </tr>
                     <tr>
                         <td><strong>Make.com</strong></td>
@@ -424,49 +427,50 @@
                         <td>751</td>
                         <td>725</td>
                         <td>743</td>
-                        <td class="growth-positive">+2.5%</td>
-                        <td class="growth-negative">-35.0%</td>
+                        <td>803</td>
+                        <td class="growth-positive">+8.1%</td>
+                        <td class="growth-negative">-29.7%</td>
                     </tr>
                 </tbody>
             </table>
 
             <div class="info-box">
                 <h4>Platform Reality Check</h4>
-                <p><strong>Zapier extended its market dominance</strong> with 46.6% share—the highest since tracking began—by declining less (-2.6%) than the overall market (-6.5%). n8n's decline steepened to -8.6% (1,403 jobs, 38.0% share), the third consecutive month of accelerating losses. Make.com posted a surprise +2.5% to 743 jobs—the first growth in five months, though still down -35.0% since May. n8n's total growth since May has eroded from +26.1% (December) to +6.4%, while Zapier's resilience solidifies its leadership position.</p>
+                <p><strong>All three major platforms grew simultaneously</strong> for the first time since July 2025. Zapier maintained its dominant position at 1,826 jobs (46.4% share, +6.1%). n8n broke its three-month accelerating decline with +4.3% growth to 1,464 jobs, rebounding total growth since May to +11.0%. Make.com posted its second consecutive positive month at +8.1% to 803 jobs, confirming the recovery trend. The platform landscape is the healthiest it's been since summer 2025.</p>
             </div>
 
-            <h3>February Market Share Evolution</h3>
+            <h3>March Market Share Evolution</h3>
             <table>
                 <thead>
                     <tr>
                         <th>Platform</th>
                         <th>May Share</th>
-                        <th>January Share</th>
                         <th>February Share</th>
-                        <th>May&rarr;Feb Change</th>
+                        <th>March Share</th>
+                        <th>May&rarr;Mar Change</th>
                     </tr>
                 </thead>
                 <tbody>
                     <tr>
                         <td><strong>Zapier</strong></td>
                         <td>52.5%</td>
-                        <td>44.8%</td>
                         <td>46.6%</td>
-                        <td class="growth-negative">-5.9 pts</td>
+                        <td>46.4%</td>
+                        <td class="growth-negative">-6.1 pts</td>
                     </tr>
                     <tr>
                         <td><strong>n8n</strong></td>
                         <td>31.0%</td>
-                        <td>38.9%</td>
                         <td>38.0%</td>
-                        <td class="growth-positive">+7.0 pts</td>
+                        <td>37.2%</td>
+                        <td class="growth-positive">+6.2 pts</td>
                     </tr>
                     <tr>
                         <td><strong>Make.com</strong></td>
                         <td>26.8%</td>
-                        <td>18.4%</td>
                         <td>20.1%</td>
-                        <td class="growth-negative">-6.7 pts</td>
+                        <td>20.4%</td>
+                        <td class="growth-negative">-6.4 pts</td>
                     </tr>
                 </tbody>
             </table>
@@ -486,7 +490,8 @@
                         <th>December</th>
                         <th>January</th>
                         <th>February</th>
-                        <th>10-Mo Change</th>
+                        <th>March</th>
+                        <th>11-Mo Change</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -502,7 +507,8 @@
                         <td>$37.58</td>
                         <td>$40.20</td>
                         <td>$43.27</td>
-                        <td class="growth-positive">+10.7%</td>
+                        <td>$40.67</td>
+                        <td class="growth-positive">+4.0%</td>
                     </tr>
                     <tr>
                         <td><strong>High-Paying Jobs ($75+)</strong></td>
@@ -516,7 +522,8 @@
                         <td>144</td>
                         <td>165</td>
                         <td>170</td>
-                        <td class="growth-positive">+11.1%</td>
+                        <td>167</td>
+                        <td class="growth-positive">+9.2%</td>
                     </tr>
                 </tbody>
             </table>
@@ -535,6 +542,7 @@
                         <th>Nov&rarr;Dec</th>
                         <th>Dec&rarr;Jan</th>
                         <th>Jan&rarr;Feb</th>
+                        <th>Feb&rarr;Mar</th>
                         <th>Trend</th>
                     </tr>
                 </thead>
@@ -550,7 +558,8 @@
                         <td class="growth-positive">+5.5%</td>
                         <td class="growth-positive">+0.8%</td>
                         <td class="growth-negative">-2.6%</td>
-                        <td>Most resilient</td>
+                        <td class="growth-positive">+6.1%</td>
+                        <td>Consistent leader</td>
                     </tr>
                     <tr>
                         <td><strong>n8n</strong></td>
@@ -563,7 +572,8 @@
                         <td class="growth-negative">-3.8%</td>
                         <td class="growth-negative">-7.7%</td>
                         <td class="growth-negative">-8.6%</td>
-                        <td>Accelerating decline</td>
+                        <td class="growth-positive">+4.3%</td>
+                        <td>Decline broken</td>
                     </tr>
                     <tr>
                         <td><strong>Make.com</strong></td>
@@ -576,7 +586,8 @@
                         <td class="growth-negative">-7.4%</td>
                         <td class="growth-negative">-3.5%</td>
                         <td class="growth-positive">+2.5%</td>
-                        <td>Possible recovery</td>
+                        <td class="growth-positive">+8.1%</td>
+                        <td>Recovery confirmed</td>
                     </tr>
                 </tbody>
             </table>
@@ -588,28 +599,28 @@
                 <thead>
                     <tr>
                         <th>Metric</th>
-                        <th>November</th>
                         <th>December</th>
                         <th>January</th>
                         <th>February</th>
+                        <th>March</th>
                         <th>Trend</th>
                     </tr>
                 </thead>
                 <tbody>
                     <tr>
                         <td>Rate premium for multi-platform</td>
-                        <td>+30%</td>
                         <td>+32%</td>
                         <td>+35%</td>
                         <td>+38%</td>
+                        <td>+40%</td>
                         <td>Premium widening</td>
                     </tr>
                     <tr>
                         <td>CRM + Platform premium</td>
-                        <td>+28%</td>
                         <td>+35%</td>
                         <td>+38%</td>
                         <td>+42%</td>
+                        <td>+45%</td>
                         <td>CRM specialization critical</td>
                     </tr>
                 </tbody>
@@ -622,8 +633,8 @@
             <h3>Top Applications & CRM Platforms: Ten-Month Comparison</h3>
 
             <div class="update-box">
-                <h4>📊 February Application Trends</h4>
-                <p>February shows a CRM rotation: <strong>Salesforce surged +25.0%</strong> to 110 jobs (+26.4% since May, strongest CRM growth) and <strong>Zoho recovered +46.3%</strong> from January's collapse to 120 jobs. HubSpot held rock solid (-0.3%), while GoHighLevel pulled back -9.3% after January's Q1 budget surge. All four dedicated CRMs remain positive since May—CRM demand is structurally resilient. Meanwhile, Notion (-11.0%), Excel (-11.4%), and Airtable (-9.2%) continued declining. <strong>Rates surged to $43.27/hr</strong> (+7.6%)—a second consecutive all-time high—with 170 high-paying jobs (4.6% share, new record).</p>
+                <h4>📊 March Application Trends</h4>
+                <p>March shows the CRM pendulum swinging back: <strong>GoHighLevel surged +18.5%</strong> to 693 jobs (all-time tracking high, +23.5% since May) and <strong>HubSpot grew +7.4%</strong> to 375 jobs (+12.3% since May). Meanwhile Salesforce corrected -20.0% and Zoho pulled back -15.8% from February's surges. Generic CRM mentions hit an all-time high at 1,434 (+19.3% since May). <strong>QuickBooks surged +28.8%</strong> to 94 jobs (+30.6% since May, strongest total growth of any application). Rates corrected to <strong>$40.67/hr</strong> (-6.0% from February's peak)—still third-highest ever.</p>
             </div>
 
             <table>
@@ -640,7 +651,8 @@
                         <th>Dec</th>
                         <th>Jan</th>
                         <th>Feb</th>
-                        <th>Jan&rarr;Feb</th>
+                        <th>Mar</th>
+                        <th>Feb&rarr;Mar</th>
                         <th>Total Change</th>
                     </tr>
                 </thead>
@@ -657,8 +669,9 @@
                         <td>562</td>
                         <td>645</td>
                         <td>585</td>
-                        <td class="growth-negative">-9.3%</td>
-                        <td class="growth-positive">+4.3%</td>
+                        <td>693</td>
+                        <td class="growth-positive">+18.5%</td>
+                        <td class="growth-positive">+23.5%</td>
                     </tr>
                     <tr>
                         <td><strong>Google Sheets</strong></td>
@@ -672,8 +685,9 @@
                         <td>552</td>
                         <td>537</td>
                         <td>495</td>
-                        <td class="growth-negative">-7.8%</td>
-                        <td class="growth-negative">-37.0%</td>
+                        <td>527</td>
+                        <td class="growth-positive">+6.5%</td>
+                        <td class="growth-negative">-33.0%</td>
                     </tr>
                     <tr>
                         <td><strong>Airtable</strong></td>
@@ -687,8 +701,9 @@
                         <td>492</td>
                         <td>467</td>
                         <td>424</td>
-                        <td class="growth-negative">-9.2%</td>
-                        <td class="growth-negative">-36.3%</td>
+                        <td>435</td>
+                        <td class="growth-positive">+2.6%</td>
+                        <td class="growth-negative">-34.7%</td>
                     </tr>
                     <tr>
                         <td><strong>HubSpot</strong> <em>(CRM)</em></td>
@@ -702,8 +717,9 @@
                         <td>333</td>
                         <td>350</td>
                         <td>349</td>
-                        <td class="growth-positive">-0.3%</td>
-                        <td class="growth-positive">+4.5%</td>
+                        <td>375</td>
+                        <td class="growth-positive">+7.4%</td>
+                        <td class="growth-positive">+12.3%</td>
                     </tr>
                     <tr>
                         <td><strong>Slack</strong></td>
@@ -717,8 +733,9 @@
                         <td>321</td>
                         <td>307</td>
                         <td>316</td>
-                        <td class="growth-positive">+2.9%</td>
-                        <td class="growth-negative">-34.4%</td>
+                        <td>335</td>
+                        <td class="growth-positive">+6.0%</td>
+                        <td class="growth-negative">-30.5%</td>
                     </tr>
                     <tr>
                         <td><strong>Excel</strong></td>
@@ -732,8 +749,9 @@
                         <td>382</td>
                         <td>316</td>
                         <td>280</td>
-                        <td class="growth-negative">-11.4%</td>
-                        <td class="growth-negative">-43.3%</td>
+                        <td>251</td>
+                        <td class="growth-negative">-10.4%</td>
+                        <td class="growth-negative">-49.2%</td>
                     </tr>
                     <tr>
                         <td><strong>Notion</strong></td>
@@ -747,8 +765,9 @@
                         <td>341</td>
                         <td>273</td>
                         <td>243</td>
-                        <td class="growth-negative">-11.0%</td>
-                        <td class="growth-negative">-43.9%</td>
+                        <td>229</td>
+                        <td class="growth-negative">-5.8%</td>
+                        <td class="growth-negative">-47.1%</td>
                     </tr>
                     <tr>
                         <td><strong>ClickUp</strong></td>
@@ -762,8 +781,9 @@
                         <td>169</td>
                         <td>146</td>
                         <td>134</td>
-                        <td class="growth-negative">-8.2%</td>
-                        <td class="growth-negative">-31.3%</td>
+                        <td>116</td>
+                        <td class="growth-negative">-13.4%</td>
+                        <td class="growth-negative">-40.5%</td>
                     </tr>
                     <tr>
                         <td><strong>Zoho</strong> <em>(CRM)</em></td>
@@ -777,8 +797,9 @@
                         <td>122</td>
                         <td>82</td>
                         <td>120</td>
-                        <td class="growth-positive">+46.3%</td>
-                        <td class="growth-positive">+16.5%</td>
+                        <td>101</td>
+                        <td class="growth-negative">-15.8%</td>
+                        <td class="growth-negative">-1.9%</td>
                     </tr>
                     <tr>
                         <td><strong>Salesforce</strong> <em>(CRM)</em></td>
@@ -792,8 +813,9 @@
                         <td>96</td>
                         <td>88</td>
                         <td>110</td>
-                        <td class="growth-positive">+25.0%</td>
-                        <td class="growth-positive">+26.4%</td>
+                        <td>88</td>
+                        <td class="growth-negative">-20.0%</td>
+                        <td class="growth-positive">+1.1%</td>
                     </tr>
                     <tr>
                         <td><strong>Monday.com</strong></td>
@@ -807,8 +829,9 @@
                         <td>90</td>
                         <td>102</td>
                         <td>101</td>
-                        <td class="growth-positive">-1.0%</td>
-                        <td class="growth-negative">-6.5%</td>
+                        <td>104</td>
+                        <td class="growth-positive">+3.0%</td>
+                        <td class="growth-negative">-3.7%</td>
                     </tr>
                     <tr>
                         <td><strong>Trello</strong></td>
@@ -822,8 +845,9 @@
                         <td>47</td>
                         <td>26</td>
                         <td>24</td>
-                        <td class="growth-negative">-7.7%</td>
-                        <td class="growth-negative">-68.0%</td>
+                        <td>31</td>
+                        <td class="growth-positive">+29.2%</td>
+                        <td class="growth-negative">-58.7%</td>
                     </tr>
                 </tbody>
             </table>
@@ -834,9 +858,9 @@
                     <tr>
                         <th>CRM Category</th>
                         <th>May</th>
-                        <th>January</th>
                         <th>February</th>
-                        <th>Jan&rarr;Feb</th>
+                        <th>March</th>
+                        <th>Feb&rarr;Mar</th>
                         <th>Analysis</th>
                     </tr>
                 </thead>
@@ -844,50 +868,50 @@
                     <tr>
                         <td><strong>Generic "CRM" mentions</strong></td>
                         <td>1,202</td>
-                        <td>1,239</td>
                         <td>1,241</td>
-                        <td class="growth-positive">+0.2%</td>
-                        <td>Steady demand (+3.2% since May)</td>
+                        <td>1,434</td>
+                        <td class="growth-positive">+15.6%</td>
+                        <td>All-time high (+19.3% since May)</td>
                     </tr>
                     <tr>
                         <td><strong>GoHighLevel</strong></td>
                         <td>561</td>
-                        <td>645</td>
                         <td>585</td>
-                        <td class="growth-negative">-9.3%</td>
-                        <td>Post-Q1 normalization (+4.3% since May)</td>
+                        <td>693</td>
+                        <td class="growth-positive">+18.5%</td>
+                        <td>All-time high (+23.5% since May)</td>
                     </tr>
                     <tr>
                         <td><strong>HubSpot</strong></td>
                         <td>334</td>
-                        <td>350</td>
                         <td>349</td>
-                        <td class="growth-positive">-0.3%</td>
-                        <td>Rock solid (+4.5% since May)</td>
+                        <td>375</td>
+                        <td class="growth-positive">+7.4%</td>
+                        <td>Strongest since August (+12.3% since May)</td>
                     </tr>
                     <tr>
                         <td><strong>Salesforce</strong></td>
                         <td>87</td>
-                        <td>88</td>
                         <td>110</td>
-                        <td class="growth-positive">+25.0%</td>
-                        <td>Surging (+26.4% since May)</td>
+                        <td>88</td>
+                        <td class="growth-negative">-20.0%</td>
+                        <td>Post-surge correction (+1.1% since May)</td>
                     </tr>
                     <tr>
                         <td><strong>Zoho</strong></td>
                         <td>103</td>
-                        <td>82</td>
                         <td>120</td>
-                        <td class="growth-positive">+46.3%</td>
-                        <td>Sharp recovery (+16.5% since May)</td>
+                        <td>101</td>
+                        <td class="growth-negative">-15.8%</td>
+                        <td>Pullback (-1.9% since May)</td>
                     </tr>
                     <tr>
                         <td><strong>Alternative CRMs</strong><br><em>(Airtable, Notion, ClickUp)</em></td>
                         <td>1,294</td>
-                        <td>886</td>
                         <td>801</td>
-                        <td class="growth-negative">-9.6%</td>
-                        <td>Continued decline, down -38.1% total</td>
+                        <td>780</td>
+                        <td class="growth-negative">-2.6%</td>
+                        <td>Continued decline, down -39.7% total</td>
                     </tr>
                 </tbody>
             </table>
@@ -895,12 +919,12 @@
             <div class="key-insights">
                 <h4>Application Market Dynamics:</h4>
                 <ul>
-                    <li><strong>CRM Rotation</strong>: Salesforce surged +25.0% and Zoho recovered +46.3%, while GoHighLevel pulled back -9.3% from Q1 surge</li>
-                    <li><strong>All CRMs Positive</strong>: All four dedicated CRMs remain positive since May (+4.3% to +26.4%)—CRM is the market's growth engine</li>
-                    <li><strong>HubSpot Ultra-Stable</strong>: -0.3% MoM, +4.5% total—most predictable application in the dataset</li>
-                    <li><strong>Rate Acceleration</strong>: $43.27/hr average (+7.6% MoM)—second consecutive all-time high</li>
-                    <li><strong>Premium Expansion</strong>: 170 high-paying jobs ($75+), 4.6% market share—new record for premium concentration</li>
-                    <li><strong>Trello Extinction</strong>: -7.7% MoM to 24 jobs (-68.0% since May)—functionally dead</li>
+                    <li><strong>CRM Rotation Continues</strong>: GoHighLevel surged +18.5% to all-time high (693), HubSpot +7.4%, while Salesforce corrected -20.0% and Zoho -15.8%</li>
+                    <li><strong>CRM Demand Expanding</strong>: Generic CRM mentions at all-time high (1,434, +19.3% since May)—demand growing, not just rotating</li>
+                    <li><strong>GoHighLevel Dominates</strong>: 693 jobs is the highest single-month CRM count since tracking began</li>
+                    <li><strong>Rate Correction</strong>: $40.67/hr (-6.0% from Feb peak)—third-highest ever, structural floor above $40</li>
+                    <li><strong>Premium Stable</strong>: 167 high-paying jobs ($75+), 4.2% share—expert tier expanded to 95 jobs</li>
+                    <li><strong>QuickBooks Surges</strong>: +28.8% MoM to 94 jobs (+30.6% since May)—strongest total growth of any application</li>
                 </ul>
             </div>
         </section>
@@ -932,7 +956,7 @@
                 </div>
 
                 <div class="chart-container">
-                    <h3>Platform Market Share (February 2026)</h3>
+                    <h3>Platform Market Share (March 2026)</h3>
                     <canvas id="marketShareChart"></canvas>
                 </div>
             </div>
@@ -941,13 +965,13 @@
         <section id="compensation">
             <h2>Compensation Analysis & Market Rates</h2>
 
-            <h3>Rate Trends: February Rate Acceleration</h3>
+            <h3>Rate Trends: March Correction from Q1 Peak</h3>
             <div class="info-box">
-                <h4>📈 Second Consecutive All-Time High</h4>
-                <p>February 2026 extended the rate surge: average hourly rates jumped to <strong>$43.27/hr (+7.6% MoM)</strong>—a second consecutive all-time high after January's $40.20. Two months of 7%+ rate growth is unprecedented in 10 months of tracking. High-paying jobs ($75+) rose to 170 (4.6% share, new record), with 29 ultra-premium roles at $150+/hr and max rates reaching $999/hr. The market is 33.2% smaller than peak but pays 9.2% more. Most realistic rates: $50-80/hr for experienced consultants, $80-250/hr for specialists.</p>
+                <h4>📊 Healthy Correction, Structural Floor Above $40</h4>
+                <p>March 2026 saw rates correct to <strong>$40.67/hr (-6.0% from February's $43.27 peak)</strong>—still the third-highest rate ever recorded and above January's $40.20 all-time high. The correction was expected after two months of 7%+ growth. High-paying jobs ($75+) held at 167 (4.2% share), with the expert tier ($75-100) expanding from 82 to 95 jobs. The structural shift above $40/hr appears genuine. Most realistic rates: $50-80/hr for experienced consultants, $80-250/hr for specialists.</p>
             </div>
 
-            <h3>Realistic Rate Ranges (February 2026)</h3>
+            <h3>Realistic Rate Ranges (March 2026)</h3>
             <table>
                 <thead>
                     <tr>
@@ -991,14 +1015,14 @@
                 </tbody>
             </table>
 
-            <h3>Rate Analysis: February Acceleration</h3>
+            <h3>Rate Analysis: March Correction</h3>
             <table>
                 <thead>
                     <tr>
                         <th>Metric</th>
                         <th>May</th>
-                        <th>January</th>
                         <th>February</th>
+                        <th>March</th>
                         <th>Insight</th>
                     </tr>
                 </thead>
@@ -1006,170 +1030,170 @@
                     <tr>
                         <td><strong>Average Rate</strong></td>
                         <td>$39.10/hr</td>
-                        <td>$40.20/hr</td>
                         <td>$43.27/hr</td>
-                        <td>Second all-time high (+7.6% MoM)</td>
+                        <td>$40.67/hr</td>
+                        <td>Corrected from peak, still third-highest ever</td>
                     </tr>
                     <tr>
                         <td><strong>High-Paying ($75+)</strong></td>
                         <td>153 jobs</td>
-                        <td>165 jobs</td>
                         <td>170 jobs</td>
-                        <td>Premium share record (4.6%)</td>
+                        <td>167 jobs</td>
+                        <td>Stable (4.2% share), expert tier expanded</td>
                     </tr>
                     <tr>
                         <td><strong>Max Rate Observed</strong></td>
                         <td>$999/hr</td>
-                        <td>$700/hr</td>
                         <td>$999/hr</td>
-                        <td>Ultra-premium expanding</td>
+                        <td>$999/hr</td>
+                        <td>Ultra-premium consistent</td>
                     </tr>
                 </tbody>
             </table>
 
-            <h3>High-Value February Insights</h3>
+            <h3>High-Value March Insights</h3>
             <div class="info-box">
-                <h4>💰 Premium Market Accelerating</h4>
-                <p>February's 170 high-paying jobs ($75+/hr) represent <strong>4.6% of total market</strong> (up from 4.2% in January, 3.6% in May)—the highest premium share ever recorded. Ultra-premium roles ($150+) expanded to 29 jobs. Two consecutive months of 7%+ rate growth to $43.27/hr confirms a structural shift. CRM specialization (all four CRMs positive since May), AI integration, and platform depth drive premium rates. The market is 33.2% smaller than peak but pays 9.2% more.</p>
+                <h4>💰 Premium Market Redistributing</h4>
+                <p>March's 167 high-paying jobs ($75+/hr) represent <strong>4.2% of total market</strong>—stable after February's 4.6% peak. Ultra-premium ($150+) contracted from 29 to 15 jobs, but the expert tier ($75-100) expanded from 82 to 95. The premium market is broadening to more accessible entry points rather than concentrating at the top. CRM specialization (GoHighLevel at all-time high, HubSpot surging), AI integration (voice agents emerging at $150-250/hr), and platform depth continue driving premium rates.</p>
             </div>
         </section>
 
         <section id="opportunities">
-            <h2>🎯 Strategic Opportunities Guide (February 2026 Update)</h2>
+            <h2>🎯 Strategic Opportunities Guide (March 2026 Update)</h2>
 
             <div class="market-alert">
-                <h4>📉 Market Reality: Fewer Jobs, Higher Rates Than Ever</h4>
-                <p>February's -6.5% volume decline to 3,690 jobs (new tracking low, -33.2% from peak) paired with a +7.6% rate surge to $43.27/hr (second consecutive all-time high) tells the definitive story: the commodity market is gone, and what remains pays dramatically more. 170 high-paying jobs at 4.6% share. 29 ultra-premium roles at $150+. All four CRMs positive since May. <strong>Salesforce surged +25.0%, Zoho recovered +46.3%, and premium work keeps expanding.</strong> The specialist economy is no longer emerging—it's here.</p>
+                <h4>📈 Market Reality: Spring Bounce with All Platforms Growing</h4>
+                <p>March's +6.7% volume rebound to 3,939 jobs—the strongest growth since summer—paired with a rate correction to $40.67/hr (still third-highest ever) signals market equilibrium. All three platforms grew simultaneously for the first time since July 2025. GoHighLevel hit an all-time high of 693 jobs. n8n broke its three-month decline. Generic CRM mentions at record levels (1,434). <strong>167 high-paying jobs at 4.2% share. More opportunity, still premium rates.</strong></p>
             </div>
 
             <h3>High-Value Opportunities (In Stabilized Market)</h3>
 
-            <h4>1. CRM + Automation Specialist ($75-180/hr)</h4>
-            <p><strong>Market Growth Engine:</strong> All four CRMs positive since May (+4.3% to +26.4%)—Salesforce surging, HubSpot stable, GoHighLevel largest by volume</p>
+            <h4>1. GoHighLevel Agency Automation ($100-150/hr)</h4>
+            <p><strong>All-Time High:</strong> 693 jobs (+18.5% MoM, +23.5% since May)—dominant CRM by volume, agency demand at peak</p>
             <ul>
                 <li><strong>Why Premium:</strong>
                     <ul>
-                        <li>CRM demand structurally resilient—only category where all major apps positive since May</li>
-                        <li>Salesforce surging +26.4%, GoHighLevel +4.3%, HubSpot +4.5%, Zoho +16.5%</li>
-                        <li>Enterprise and agency budgets driving premium CRM automation</li>
+                        <li>Highest single-month CRM count since tracking began</li>
+                        <li>Agency automation demand at peak levels</li>
+                        <li>White-label solution development valuable</li>
+                        <li>GoHighLevel + n8n/Zapier combinations</li>
+                    </ul>
+                </li>
+                <li><strong>Market Position:</strong> Agency CRM specialization is the highest-volume opportunity</li>
+                <li><strong>Rate Range:</strong> $100-150/hr for GoHighLevel + platform expertise</li>
+            </ul>
+
+            <h4>2. CRM + Automation Specialist ($75-180/hr)</h4>
+            <p><strong>Market Growth Engine:</strong> Generic CRM mentions at all-time high (1,434, +19.3% since May)—CRM demand expanding</p>
+            <ul>
+                <li><strong>Why Premium:</strong>
+                    <ul>
+                        <li>CRM demand expanding—generic mentions at record levels</li>
+                        <li>GoHighLevel +23.5%, HubSpot +12.3%, Salesforce +1.1% since May</li>
+                        <li>CRM RevOps consulting at $210/hr seen in March</li>
                         <li>Multi-CRM integration and migration projects valuable</li>
                     </ul>
                 </li>
-                <li><strong>Market Position:</strong> CRM specialization is the single strongest positioning strategy</li>
+                <li><strong>Market Position:</strong> CRM specialization remains the single strongest positioning strategy</li>
                 <li><strong>Rate Range:</strong> $75-180/hr for CRM + platform expertise</li>
             </ul>
 
-            <h4>2. Zapier Advanced Implementation ($75-150/hr)</h4>
-            <p><strong>Market Leader:</strong> 1,721 jobs (46.6% share)—highest market share ever, most resilient platform</p>
-            <ul>
-                <li><strong>Why Premium:</strong>
-                    <ul>
-                        <li>Largest platform by volume, highest share ever (46.6%)</li>
-                        <li>Zapier Tables/Interfaces differentiation</li>
-                        <li>Enterprise deployment and Zapier for Teams</li>
-                        <li>Complex multi-step workflow design</li>
-                    </ul>
-                </li>
-                <li><strong>Market Position:</strong> Reliable primary platform choice</li>
-                <li><strong>Rate Range:</strong> $75-150/hr for advanced Zapier work</li>
-            </ul>
-
-            <h4>3. AI-Enhanced Automation ($120-250/hr)</h4>
-            <p><strong>Critical Differentiator:</strong> AI separates premium from commodity consultants</p>
+            <h4>3. AI Voice Agent Development ($130-250/hr)</h4>
+            <p><strong>Emerging Premium Niche:</strong> Multiple $150-250/hr roles for AI voice automation (Retell, Vapi)</p>
             <ul>
                 <li><strong>Skills Needed:</strong>
                     <ul>
-                        <li>n8n or Zapier + OpenAI/Claude APIs</li>
-                        <li>Document processing and extraction</li>
-                        <li>RAG implementation</li>
-                        <li>Intelligent workflow routing</li>
+                        <li>Retell or Vapi platform expertise</li>
+                        <li>AI/LLM API integration</li>
+                        <li>Industry-specific voice agent design (construction, real estate, services)</li>
+                        <li>n8n or Zapier for backend integration</li>
                     </ul>
                 </li>
-                <li><strong>Rate Premium:</strong> +40-60% for AI capabilities</li>
+                <li><strong>Rate Premium:</strong> +50-80% for AI voice capabilities—new premium category</li>
             </ul>
 
-            <h4>4. Salesforce Integration ($80-180/hr)</h4>
-            <p><strong>Surging:</strong> Salesforce +26.4% since May—strongest CRM growth in the dataset, enterprise budgets deploying</p>
+            <h4>4. Accounting Automation ($75-120/hr)</h4>
+            <p><strong>Strongest Total Growth:</strong> QuickBooks +30.6% since May (94 jobs), Xero +22.9% (43 jobs)</p>
             <ul>
                 <li><strong>Opportunities:</strong>
                     <ul>
-                        <li>Salesforce + Zapier/n8n (enterprise automation)</li>
-                        <li>Data migration and system integration</li>
-                        <li>Enterprise workflow consulting</li>
-                        <li>Compliance and audit trail automation</li>
+                        <li>QuickBooks + Zapier/Make.com integration</li>
+                        <li>Xero automation workflows</li>
+                        <li>Financial reporting and invoicing automation</li>
+                        <li>Tax season workflow optimization</li>
                     </ul>
                 </li>
-                <li><strong>Why Resilient:</strong> CRM is essential business function, not discretionary</li>
-                <li><strong>Rate Range:</strong> $75-150/hr for CRM specialists</li>
+                <li><strong>Why Resilient:</strong> Measurable ROI, essential function, recession-resistant</li>
+                <li><strong>Rate Range:</strong> $75-120/hr for accounting automation specialists</li>
             </ul>
 
-            <h3>Platform Strategy (February Reality Check)</h3>
+            <h3>Platform Strategy (March Reality Check)</h3>
 
-            <h4>Priority 1: Zapier—Dominant Leader</h4>
+            <h4>Priority 1: Zapier—Consistent Leader</h4>
             <ul>
-                <li>Market leader with 1,721 jobs (46.6% share—highest ever)</li>
-                <li>Most resilient platform (-2.6% vs market -6.5%)</li>
+                <li>Market leader with 1,826 jobs (46.4% share)—highest count since December</li>
+                <li>+6.1% MoM, consistent performance across market conditions</li>
                 <li>Broadest market, most accessible clients</li>
-                <li><strong>Action:</strong> Strongest primary platform choice</li>
+                <li><strong>Action:</strong> Primary platform choice remains strongest</li>
             </ul>
 
-            <h4>Priority 2: n8n—Premium But Declining</h4>
+            <h4>Priority 2: n8n—Decline Broken, Premium Intact</h4>
             <ul>
-                <li>1,403 jobs (38.0% share), still +6.4% since May but eroding fast</li>
-                <li>Three months of accelerating decline (-3.8%, -7.7%, -8.6%)</li>
-                <li>Technical depth still commands premium rates</li>
-                <li><strong>Action:</strong> Premium positioning valid, but consider dual-platform approach</li>
+                <li>1,464 jobs (37.2% share), +11.0% since May (rebounded from +6.4%)</li>
+                <li>+4.3% MoM breaks three months of accelerating decline</li>
+                <li>Technical depth commands premium ($100-200/hr)</li>
+                <li><strong>Action:</strong> Premium positioning reaffirmed; confidence restored</li>
             </ul>
 
             <h4>Priority 3: CRM Specialization—Mandatory</h4>
             <ul>
-                <li>Salesforce: +26.4% since May, enterprise surge</li>
-                <li>Zoho: +16.5% since May, mid-market recovery</li>
-                <li>HubSpot: +4.5% since May, rock-solid stability</li>
-                <li>GoHighLevel: +4.3% since May, agency focus</li>
-                <li><strong>Action:</strong> Pair any platform with CRM specialty—all four CRMs positive</li>
+                <li>GoHighLevel: +23.5% since May, all-time high at 693 jobs</li>
+                <li>HubSpot: +12.3% since May, strongest since August</li>
+                <li>Salesforce: +1.1% since May, corrected from February surge</li>
+                <li>Generic CRM: All-time high at 1,434 (+19.3% since May)</li>
+                <li><strong>Action:</strong> GoHighLevel for agencies, HubSpot for enterprise—CRM demand expanding</li>
             </ul>
 
-            <h4>Watch: Make.com Recovery</h4>
+            <h4>Confirmed: Make.com Recovery</h4>
             <ul>
-                <li>+2.5% MoM to 743 jobs—first growth in five months</li>
-                <li>Still -35.0% since May—recovery unconfirmed</li>
-                <li><strong>Action:</strong> Watch March data; useful as secondary skill</li>
+                <li>+8.1% MoM to 803 jobs—second consecutive positive month</li>
+                <li>Still -29.7% since May, but recovery trend confirmed</li>
+                <li><strong>Action:</strong> Viable secondary platform; reassess as primary if Q2 growth continues</li>
             </ul>
 
-            <h3>Capitalizing on Rate Acceleration</h3>
+            <h3>Capitalizing on the Volume Rebound</h3>
 
             <div class="action-items">
-                <h4>For All Consultants (Rates +7.6% to $43.27—Second All-Time High):</h4>
+                <h4>For All Consultants (Volume +6.7%, Rates at $40.67—Third-Highest Ever):</h4>
                 <ul>
-                    <li><strong>Immediately:</strong> Raise rates 15-25%—two months of 7%+ growth means market is pulling rates up</li>
-                    <li><strong>Q1-Q2 Strategy:</strong> Target enterprise clients deploying budgets</li>
-                    <li><strong>Positioning:</strong> Lead with CRM + AI, platform as delivery tool</li>
-                    <li><strong>Pricing:</strong> Value-based packages, not hourly competition</li>
+                    <li><strong>Immediately:</strong> Hold rates steady—$40.67 average supports premium pricing despite correction</li>
+                    <li><strong>Q2 Strategy:</strong> More jobs available—increase proposal volume while staying selective</li>
+                    <li><strong>Positioning:</strong> Lead with CRM expertise (GoHighLevel at all-time high, generic CRM at record)</li>
+                    <li><strong>New Opportunity:</strong> AI voice agents (Retell/Vapi) at $150-250/hr—emerging premium niche</li>
                 </ul>
 
                 <h4>For Growing Consultants (Revenue Stable/Up):</h4>
                 <ul>
-                    <li>Raise rates 20-30% immediately—market supports it</li>
-                    <li>Acquire competitors' clients as weaker consultants exit</li>
-                    <li>Expand into vacated market segments</li>
-                    <li>Invest in thought leadership and brand</li>
+                    <li>Volume rebound means more opportunity—expand selectively</li>
+                    <li>GoHighLevel at all-time high—add if not in your stack</li>
+                    <li>Explore AI voice agent development as new premium category</li>
+                    <li>Build retainer relationships with Q1 project clients</li>
                 </ul>
 
                 <h4>For Struggling Consultants (Revenue Down):</h4>
                 <ul>
-                    <li>Q1 is your best opportunity—budget resets create openings</li>
-                    <li>Add Salesforce or GoHighLevel expertise (CRM demand structurally resilient)</li>
-                    <li>Pair with AI capabilities for premium positioning</li>
-                    <li>Target $60-80/hr minimum, refuse commodity pricing</li>
+                    <li>Volume rebound creates more accessible opportunities</li>
+                    <li>Add GoHighLevel or HubSpot expertise (both surging)</li>
+                    <li>Accounting automation (QuickBooks +30.6%)—strong ROI niche</li>
+                    <li>Target $60-80/hr minimum, all three platforms growing</li>
                 </ul>
 
                 <h4>Red Flags to Avoid:</h4>
                 <ul>
-                    <li>Lowering rates when market average just hit all-time high</li>
-                    <li>Staying Make.com-only or platform-only generalist</li>
-                    <li>Ignoring AI capabilities (now table stakes)</li>
-                    <li>Trello, Slack, or Excel-only specialization (structural decline)</li>
+                    <li>Lowering rates because of correction—$40.67 still well above $40</li>
+                    <li>Platform-only generalist positioning without CRM focus</li>
+                    <li>Ignoring AI capabilities (voice agents emerging as premium)</li>
+                    <li>Excel, Notion, or ClickUp-only specialization (structural decline)</li>
                     <li>Generic positioning without CRM/industry focus</li>
                 </ul>
             </div>
@@ -1181,41 +1205,41 @@
             <h3>🎯 Critical Market Insights</h3>
 
             <div class="key-insights">
-                <h4>February 2026 Market Realities:</h4>
+                <h4>March 2026 Market Realities:</h4>
                 <ol>
-                    <li><strong>New Tracking Low</strong>: 3,690 jobs (-6.5% MoM, -33.2% from July peak)—contraction continues</li>
-                    <li><strong>Second Rate Record</strong>: $43.27/hr average (+7.6% MoM)—two consecutive all-time highs</li>
-                    <li><strong>Premium Share Record</strong>: 170 high-paying jobs ($75+), 4.6% share—highest ever</li>
-                    <li><strong>Salesforce Surges</strong>: +25.0% MoM, +26.4% since May—strongest CRM growth</li>
-                    <li><strong>Zapier Dominates</strong>: 46.6% market share, highest ever, most resilient platform</li>
-                    <li><strong>n8n Accelerating</strong>: -8.6% MoM, three months steepening, +6.4% since May eroding</li>
-                    <li><strong>Specialist Economy</strong>: 33.2% fewer jobs, 9.2% higher rates—quality over quantity</li>
+                    <li><strong>Spring Bounce</strong>: 3,939 jobs (+6.7% MoM, -28.7% from peak)—strongest growth since summer</li>
+                    <li><strong>Rate Correction</strong>: $40.67/hr (-6.0% from Feb)—third-highest ever, structural floor above $40</li>
+                    <li><strong>All Platforms Growing</strong>: First time since July 2025—Zapier +6.1%, n8n +4.3%, Make.com +8.1%</li>
+                    <li><strong>GoHighLevel All-Time High</strong>: 693 jobs (+18.5% MoM, +23.5% since May)—dominant CRM</li>
+                    <li><strong>n8n Decline Broken</strong>: +4.3% after three months of accelerating losses, +11.0% since May</li>
+                    <li><strong>CRM Demand Expanding</strong>: Generic CRM mentions at all-time high (1,434, +19.3% since May)</li>
+                    <li><strong>Market Equilibrium</strong>: ~3,900-4,000 jobs at $40-42/hr may be the new normal</li>
                 </ol>
             </div>
 
-            <h3>📈 Q1-Q2 2026 Market Forecast</h3>
+            <h3>📈 Q2 2026 Market Forecast</h3>
 
-            <h4>Expected Trends (March - June 2026):</h4>
+            <h4>Expected Trends (April - June 2026):</h4>
             <ul>
-                <li><strong>Volume Decline Continues</strong>: Expect 3,500-3,800 range as market seeks floor</li>
-                <li><strong>Rate Normalization</strong>: $43.27 may moderate but structural floor around $40-42/hr</li>
-                <li><strong>Q2 Stabilization</strong>: Project launches may stabilize volume by April-May</li>
-                <li><strong>Zapier Dominance</strong>: 46.6% share likely to hold or expand</li>
-                <li><strong>n8n Crossroads</strong>: If decline continues, total growth turns negative by April</li>
-                <li><strong>Make.com Watch</strong>: March data will confirm or deny recovery</li>
-                <li><strong>CRM Engine</strong>: All four CRMs positive—structural demand, not seasonal</li>
+                <li><strong>Volume Stabilization</strong>: Expect 3,800-4,100 range as market finds equilibrium</li>
+                <li><strong>Rate Normalization</strong>: $40-42/hr range likely sustainable, structural floor above $40</li>
+                <li><strong>GoHighLevel Momentum</strong>: All-time high suggests agency demand is structural</li>
+                <li><strong>n8n Recovery</strong>: Decline broken, needs sustained growth to confirm</li>
+                <li><strong>Make.com Trajectory</strong>: Two consecutive positive months—Q2 will confirm recovery</li>
+                <li><strong>CRM Expansion</strong>: Generic mentions at record levels—demand growing, not just rotating</li>
+                <li><strong>AI Voice Agents</strong>: Emerging premium niche may become measurable category</li>
             </ul>
 
             <h3>Practical Strategies by Market Position</h3>
 
             <h4>For Struggling Consultants (Revenue Down >20%):</h4>
             <ul>
-                <li><strong>Emergency Actions:</strong>
+                <li><strong>Volume Rebound Creates Opportunity:</strong>
                     <ul>
-                        <li>Q1 is the best opportunity—budget resets creating premium openings</li>
-                        <li>Add CRM expertise—all four positive since May (Salesforce +26.4%, GoHighLevel +4.3%)</li>
-                        <li>Complete OpenAI API integration course immediately</li>
-                        <li>Target $50-70/hr minimum, refuse commodity work</li>
+                        <li>+6.7% more jobs available—increase proposal activity</li>
+                        <li>Add GoHighLevel or HubSpot expertise (both surging)</li>
+                        <li>QuickBooks automation (+30.6% since May)—strong ROI niche</li>
+                        <li>Target $50-70/hr minimum, all platforms growing</li>
                     </ul>
                 </li>
             </ul>
@@ -1224,10 +1248,10 @@
             <ul>
                 <li><strong>Optimization Actions:</strong>
                     <ul>
-                        <li>Raise rates 15-20%—market just hit all-time high average</li>
-                        <li>Add AI capabilities to existing engagements</li>
-                        <li>Develop industry vertical expertise</li>
-                        <li>Build retainer relationships with top clients</li>
+                        <li>Hold rates steady—$40.67 average supports premium positioning</li>
+                        <li>Add AI voice agent capabilities (emerging premium at $150-250/hr)</li>
+                        <li>Deepen CRM expertise (GoHighLevel at all-time high)</li>
+                        <li>Build retainer relationships with Q1 project clients</li>
                     </ul>
                 </li>
             </ul>
@@ -1236,73 +1260,73 @@
             <ul>
                 <li><strong>Scale Actions:</strong>
                     <ul>
-                        <li>Shift toward strategic consulting ($150-250/hr)</li>
-                        <li>Raise rates 25-40% as market supports premium pricing</li>
-                        <li>Create AI-powered automation products</li>
-                        <li>Build team to scale delivery</li>
+                        <li>Explore AI voice agent development as new premium tier</li>
+                        <li>Expand CRM consulting (RevOps at $210/hr seen in March)</li>
+                        <li>Capitalize on volume rebound—selectively scale delivery</li>
+                        <li>Build team to handle growing opportunity set</li>
                     </ul>
                 </li>
             </ul>
 
-            <h3>⚡ Critical Success Factors (Q1-Q2 2026)</h3>
+            <h3>⚡ Critical Success Factors (Q2 2026)</h3>
 
             <div class="action-items">
                 <h4>Non-Negotiable Capabilities:</h4>
                 <ol>
-                    <li><strong>CRM Specialization</strong>: Salesforce (surging +26.4%), GoHighLevel, or HubSpot expertise</li>
-                    <li><strong>Platform Proficiency</strong>: Zapier (market leader) or n8n (technical premium)</li>
-                    <li><strong>AI Integration</strong>: OpenAI or Anthropic API implementation</li>
+                    <li><strong>CRM Specialization</strong>: GoHighLevel (all-time high), HubSpot (surging +12.3%), or Salesforce expertise</li>
+                    <li><strong>Platform Proficiency</strong>: Zapier (consistent leader) or n8n (decline broken, premium intact)</li>
+                    <li><strong>AI Integration</strong>: OpenAI/Anthropic APIs + emerging voice AI (Retell/Vapi)</li>
                     <li><strong>Value Positioning</strong>: Outcome-based pricing, not hourly competition</li>
                     <li><strong>Industry Focus</strong>: Deep knowledge in 1-2 verticals</li>
                 </ol>
 
                 <h4>Recommended Learning Path (Next 90 Days):</h4>
                 <ol>
-                    <li><strong>Week 1-2:</strong> Salesforce, GoHighLevel, or HubSpot deep-dive</li>
+                    <li><strong>Week 1-2:</strong> GoHighLevel, HubSpot, or Salesforce deep-dive</li>
                     <li><strong>Week 3-4:</strong> Zapier advanced features or n8n self-hosting</li>
-                    <li><strong>Week 5-6:</strong> OpenAI API and prompt engineering</li>
-                    <li><strong>Week 7-8:</strong> Document AI and RAG basics</li>
-                    <li><strong>Week 9-12:</strong> Industry vertical positioning (agency, healthcare, accounting)</li>
+                    <li><strong>Week 5-6:</strong> AI voice agents (Retell/Vapi) + OpenAI API</li>
+                    <li><strong>Week 7-8:</strong> QuickBooks/Xero accounting automation</li>
+                    <li><strong>Week 9-12:</strong> Industry vertical positioning (agency, construction, accounting)</li>
                 </ol>
             </div>
 
-            <h3>Final Recommendations: The Specialist Economy</h3>
+            <h3>Final Recommendations: Market Equilibrium</h3>
 
             <div class="executive-summary">
                 <h4>The Bottom Line:</h4>
-                <p>February 2026 proves the market transformation is accelerating: 3,690 monthly jobs (new low) at $43.27/hr (new high) with 170 premium opportunities at $75+/hr. <strong>The market isn't shrinking—the bottom is falling out while the top expands.</strong> Success strategies for the specialist economy:</p>
+                <p>March 2026 signals market equilibrium: 3,939 monthly jobs (+6.7%) at $40.67/hr (third-highest ever) with 167 premium opportunities at $75+/hr. <strong>The market bounced back with all platforms growing simultaneously for the first time since July 2025.</strong> Success strategies for Q2 2026:</p>
                 <ol>
-                    <li><strong>CRM First</strong>: All four CRMs positive since May—Salesforce (+26.4%), Zoho (+16.5%), HubSpot (+4.5%), GoHighLevel (+4.3%)</li>
-                    <li><strong>Platform Foundation</strong>: Zapier (46.6% share, most resilient) or n8n (premium, declining)</li>
-                    <li><strong>Premium Positioning</strong>: Target $75-150/hr, market supports it ($43.27 avg, 4.6% premium share)</li>
-                    <li><strong>AI as Standard</strong>: Integration capabilities now table stakes; advanced AI drives premium</li>
-                    <li><strong>Value Demonstration</strong>: Outcome-based pricing, case studies, ROI focus</li>
-                    <li><strong>Raise Rates Aggressively</strong>: Two consecutive months of 7%+ growth—the market is pulling rates up</li>
+                    <li><strong>CRM First</strong>: GoHighLevel at all-time high (+23.5%), HubSpot surging (+12.3%), generic CRM at record levels</li>
+                    <li><strong>Platform Foundation</strong>: Zapier (46.4% share, consistent) or n8n (decline broken, +11.0% since May)</li>
+                    <li><strong>Premium Positioning</strong>: Target $75-150/hr, $40.67 average supports it, 4.2% premium share</li>
+                    <li><strong>AI Voice Agents</strong>: Emerging premium niche at $150-250/hr (Retell/Vapi)</li>
+                    <li><strong>Accounting Niche</strong>: QuickBooks (+30.6%) and Xero (+22.9%)—strongest total growth</li>
+                    <li><strong>Hold Rates</strong>: Correction from $43.27 to $40.67 is normalization, not downturn</li>
                 </ol>
-                <p><strong>The specialist economy is here.</strong> 33.2% fewer jobs paying 9.2% more. Premium share at record highs. All four CRMs growing. The 3,690 remaining monthly jobs are dramatically higher quality and higher paying. Position as a CRM + platform + AI specialist or face the disappearing generalist market.</p>
+                <p><strong>The market is finding equilibrium.</strong> ~3,900-4,000 jobs at $40-42/hr with all platforms growing. CRM demand at record levels. GoHighLevel at all-time high. n8n's decline broken. Make.com recovery confirmed. More jobs available, still premium rates. Q2 is wide open for specialists positioned with CRM + platform + AI expertise.</p>
             </div>
 
             <div class="market-alert">
-                <h4>📊 Key Takeaways from February 2026</h4>
+                <h4>📊 Key Takeaways from March 2026</h4>
                 <ul>
-                    <li>📉 <strong>New tracking low</strong>: 3,690 jobs (-6.5% MoM, -33.2% from peak)</li>
-                    <li>✅ <strong>Second rate record</strong>: $43.27/hr average (+7.6% MoM)—unprecedented acceleration</li>
-                    <li>✅ <strong>Premium share record</strong>: 170 high-paying jobs, 4.6% share, 29 ultra-premium at $150+</li>
-                    <li>✅ <strong>Salesforce surges</strong>: +25.0% MoM, +26.4% since May—strongest CRM growth</li>
-                    <li>✅ <strong>All CRMs positive</strong>: +4.3% to +26.4% since May—CRM is the growth engine</li>
-                    <li>✅ <strong>Zapier dominates</strong>: 46.6% share, highest ever, most resilient</li>
-                    <li>⚠️ <strong>n8n at crossroads</strong>: Three months of accelerating decline, +6.4% total eroding</li>
-                    <li>🟢 <strong>Make.com shows life</strong>: +2.5% MoM, first growth in five months</li>
+                    <li>📈 <strong>Spring bounce</strong>: 3,939 jobs (+6.7% MoM)—strongest growth since summer, all three platforms up</li>
+                    <li>📊 <strong>Rate correction</strong>: $40.67/hr (-6.0% from Feb peak)—third-highest ever, floor above $40</li>
+                    <li>✅ <strong>GoHighLevel all-time high</strong>: 693 jobs (+18.5% MoM, +23.5% since May)—dominant CRM</li>
+                    <li>✅ <strong>n8n decline broken</strong>: +4.3% MoM, total growth rebounds to +11.0% since May</li>
+                    <li>✅ <strong>Make.com recovery confirmed</strong>: +8.1% MoM, second consecutive positive month</li>
+                    <li>✅ <strong>CRM demand expanding</strong>: Generic mentions at all-time high (1,434, +19.3% since May)</li>
+                    <li>🟢 <strong>Premium stable</strong>: 167 jobs at $75+ (4.2% share), expert tier expanded</li>
+                    <li>🚀 <strong>QuickBooks strongest growth</strong>: +30.6% since May—top application by total growth</li>
                 </ul>
-                <p>The contraction continues but the specialist economy thrives. Fewer jobs, dramatically higher rates. Two consecutive months of 7%+ rate growth. Premium share at record highs. All four CRMs growing. The opportunity has never been better—for consultants positioned with CRM expertise, AI capabilities, and value-based pricing.</p>
+                <p>The market bounced back. All platforms growing. CRM demand at record levels. Rates above $40. GoHighLevel at all-time high. n8n's trajectory reversed. More opportunity, still premium rates. The specialist economy continues—with more jobs available than at any point since January.</p>
             </div>
         </section>
     </main>
 
     <footer>
-        <p>Upwork Automation Market Analysis • May 2025-February 2026 • Based on 46,202 job postings</p>
+        <p>Upwork Automation Market Analysis • May 2025-March 2026 • Based on 50,141 job postings</p>
         <p>Data analysis performed using comprehensive CSV exports from Upwork automation job listings</p>
-        <p>Next update: March 2026 data to track continued market evolution</p>
+        <p>Next update: April 2026 data to track continued market evolution</p>
     </footer>
 
     <script>
@@ -1336,24 +1360,24 @@
         new Chart(platformGrowthCtx, {
             type: 'line',
             data: {
-                labels: ['May 2025', 'June 2025', 'July 2025', 'August 2025', 'September 2025', 'October 2025', 'November 2025', 'December 2025', 'January 2026', 'February 2026'],
+                labels: ['May 2025', 'June 2025', 'July 2025', 'August 2025', 'September 2025', 'October 2025', 'November 2025', 'December 2025', 'January 2026', 'February 2026', 'March 2026'],
                 datasets: [{
                     label: 'Zapier',
-                    data: [2236, 2554, 2796, 2663, 2233, 2132, 1662, 1753, 1767, 1721],
+                    data: [2236, 2554, 2796, 2663, 2233, 2132, 1662, 1753, 1767, 1721, 1826],
                     borderColor: '#FF6B6B',
                     backgroundColor: 'rgba(255, 107, 107, 0.1)',
                     tension: 0.4,
                     borderWidth: 3
                 }, {
                     label: 'n8n',
-                    data: [1319, 1794, 1984, 2155, 2099, 2024, 1729, 1663, 1535, 1403],
+                    data: [1319, 1794, 1984, 2155, 2099, 2024, 1729, 1663, 1535, 1403, 1464],
                     borderColor: '#4ECDC4',
                     backgroundColor: 'rgba(78, 205, 196, 0.1)',
                     tension: 0.4,
                     borderWidth: 3
                 }, {
                     label: 'Make.com',
-                    data: [1143, 1278, 1429, 1174, 967, 1027, 811, 751, 725, 743],
+                    data: [1143, 1278, 1429, 1174, 967, 1027, 811, 751, 725, 743, 803],
                     borderColor: '#45B7D1',
                     backgroundColor: 'rgba(69, 183, 209, 0.1)',
                     tension: 0.4,
@@ -1368,7 +1392,7 @@
                     },
                     title: {
                         display: true,
-                        text: 'Platform Job Trajectory (May 2025-February 2026) - Zapier Dominates'
+                        text: 'Platform Job Trajectory (May 2025-March 2026) - All Platforms Growing'
                     }
                 },
                 scales: {
@@ -1389,11 +1413,11 @@
         new Chart(marketVolumeCtx, {
             type: 'bar',
             data: {
-                labels: ['May 2025', 'June 2025', 'July 2025', 'August 2025', 'September 2025', 'October 2025', 'November 2025', 'December 2025', 'January 2026', 'February 2026'],
+                labels: ['May 2025', 'June 2025', 'July 2025', 'August 2025', 'September 2025', 'October 2025', 'November 2025', 'December 2025', 'January 2026', 'February 2026', 'March 2026'],
                 datasets: [{
                     label: 'Total Jobs',
-                    data: [4256, 5143, 5522, 5402, 5072, 5031, 4203, 3938, 3945, 3690],
-                    backgroundColor: ['#95E1D3', '#81C7BA', '#6DADA1', '#FFA07A', '#FF6B6B', '#FF9999', '#CC4444', '#AA3333', '#88AA44', '#CC3333'],
+                    data: [4256, 5143, 5522, 5402, 5072, 5031, 4203, 3938, 3945, 3690, 3939],
+                    backgroundColor: ['#95E1D3', '#81C7BA', '#6DADA1', '#FFA07A', '#FF6B6B', '#FF9999', '#CC4444', '#AA3333', '#88AA44', '#CC3333', '#88BB55'],
                     borderRadius: 8
                 }]
             },
@@ -1403,7 +1427,7 @@
                     legend: { display: false },
                     title: {
                         display: true,
-                        text: 'Overall Market Volume (February New Low)'
+                        text: 'Overall Market Volume (March Spring Bounce)'
                     }
                 },
                 scales: {
@@ -1424,31 +1448,31 @@
         new Chart(appEvolutionCtx, {
             type: 'line',
             data: {
-                labels: ['May', 'June', 'July', 'August', 'September', 'October', 'November', 'December', 'January', 'February'],
+                labels: ['May', 'June', 'July', 'August', 'September', 'October', 'November', 'December', 'January', 'February', 'March'],
                 datasets: [{
                     label: 'GoHighLevel',
-                    data: [561, 647, 682, 647, 662, 659, 579, 562, 645, 585],
+                    data: [561, 647, 682, 647, 662, 659, 579, 562, 645, 585, 693],
                     borderColor: '#4ECDC4',
                     borderWidth: 3,
                     tension: 0.4
                 }, {
                     label: 'HubSpot',
-                    data: [334, 396, 412, 490, 450, 447, 346, 333, 350, 349],
+                    data: [334, 396, 412, 490, 450, 447, 346, 333, 350, 349, 375],
                     borderColor: '#FF6B6B',
                     tension: 0.4
                 }, {
                     label: 'Airtable',
-                    data: [666, 779, 916, 731, 604, 611, 505, 492, 467, 424],
+                    data: [666, 779, 916, 731, 604, 611, 505, 492, 467, 424, 435],
                     borderColor: '#45B7D1',
                     tension: 0.4
                 }, {
                     label: 'Zoho',
-                    data: [103, 113, 175, 163, 124, 141, 128, 122, 82, 120],
+                    data: [103, 113, 175, 163, 124, 141, 128, 122, 82, 120, 101],
                     borderColor: '#95E1D3',
                     tension: 0.4
                 }, {
                     label: 'Slack',
-                    data: [482, 485, 625, 519, 460, 461, 354, 321, 307, 316],
+                    data: [482, 485, 625, 519, 460, 461, 354, 321, 307, 316, 335],
                     borderColor: '#F38181',
                     tension: 0.4
                 }]
@@ -1458,7 +1482,7 @@
                 plugins: {
                     title: {
                         display: true,
-                        text: 'Key Application Trends (May 2025-February 2026) - CRM Resilience'
+                        text: 'Key Application Trends (May 2025-March 2026) - GoHighLevel All-Time High'
                     },
                     legend: {
                         position: 'bottom'
@@ -1477,10 +1501,10 @@
         new Chart(rateEvolutionCtx, {
             type: 'line',
             data: {
-                labels: ['May 2025', 'June 2025', 'July 2025', 'August 2025', 'September 2025', 'October 2025', 'November 2025', 'December 2025', 'January 2026', 'February 2026'],
+                labels: ['May 2025', 'June 2025', 'July 2025', 'August 2025', 'September 2025', 'October 2025', 'November 2025', 'December 2025', 'January 2026', 'February 2026', 'March 2026'],
                 datasets: [{
                     label: 'Market Average',
-                    data: [39.10, 39.35, 39.61, 39.07, 38.74, 38.17, 38.79, 37.58, 40.20, 43.27],
+                    data: [39.10, 39.35, 39.61, 39.07, 38.74, 38.17, 38.79, 37.58, 40.20, 43.27, 40.67],
                     borderColor: '#FF6B6B',
                     backgroundColor: '#FF6B6B',
                     tension: 0.1,
@@ -1495,7 +1519,7 @@
                     },
                     title: {
                         display: true,
-                        text: 'Average Hourly Rate Evolution (Two Consecutive All-Time Highs)'
+                        text: 'Average Hourly Rate Evolution (Correction from Q1 Peak, Floor Above $40)'
                     }
                 },
                 scales: {
@@ -1516,9 +1540,9 @@
         new Chart(marketShareCtx, {
             type: 'doughnut',
             data: {
-                labels: ['Zapier (46.6%)', 'n8n (38.0%)', 'Make.com (20.1%)'],
+                labels: ['Zapier (46.4%)', 'n8n (37.2%)', 'Make.com (20.4%)'],
                 datasets: [{
-                    data: [1721, 1403, 743],
+                    data: [1826, 1464, 803],
                     backgroundColor: ['#FF6B6B', '#4ECDC4', '#45B7D1'],
                     borderWidth: 2,
                     borderColor: '#fff'
@@ -1537,7 +1561,7 @@
                     },
                     title: {
                         display: true,
-                        text: 'Platform Market Share - February 2026 (Zapier Dominates at 46.6%)'
+                        text: 'Platform Market Share - March 2026 (Zapier Leads at 46.4%)'
                     }
                 }
             }


### PR DESCRIPTION
## [0.11.0] - 2026-04-02
### Added
- upwork-analysis/app-comparison-march-2026.md
- upwork-analysis/high-paying-guide-march-2026.md
- upwork_export_filtered_2026-03.csv
- MARCH_2026_SKOOL_POST.md (Skool.com community post)
### Changed
- upwork-analysis/upwork-analysis.html: Updated to include March 2026 data (May 2025-March 2026, 11-month analysis, 50,141 total jobs)
### Key Findings
- Spring bounce: 3,939 jobs (+6.7% MoM)—strongest growth since summer, first time all three platforms grew since July 2025
- Rate correction: $40.67/hr (-6.0% from February's $43.27 peak)—third-highest ever, structural floor above $40
- GoHighLevel all-time high: 693 jobs (+18.5% MoM, +23.5% since May)—highest single-month CRM count since tracking began
- n8n decline broken: +4.3% MoM after three months of accelerating losses (-3.8%, -7.7%, -8.6%), total growth rebounds to +11.0%
- Make.com recovery confirmed: +8.1% MoM, second consecutive positive month (803 jobs)
- HubSpot surges: +7.4% MoM, +12.3% since May—strongest since August
- QuickBooks strongest total growth: +30.6% since May (94 jobs)—top application by total growth
- Generic CRM mentions all-time high: 1,434 (+19.3% since May)—CRM demand expanding
- AI voice agents emerge: $150-250/hr new premium niche (Retell, Vapi platforms)
- Market equilibrium: ~3,900-4,000 jobs at $40-42/hr may be the new normal
