### PR TITLE
[0.12.0] - 2026-05-01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,29 @@
 # CHANGELOG
 
 
+## [0.12.0] - 2026-05-01
+### Added
+- upwork-analysis/app-comparison-april-2026.md
+- upwork-analysis/high-paying-guide-april-2026.md
+- upwork_export_filtered_2026-04.csv
+- APRIL_2026_SKOOL_POST.md (Skool.com community post)
+### Changed
+- upwork-analysis/upwork-analysis.html: Updated to include April 2026 data (May 2025-April 2026, 12-month analysis, 53,786 total jobs)
+- analyze_upwork_data.py: Updated months list to include all 12 months with current naming convention (`upwork_export_filtered_YYYY-MM.csv`)
+### Key Findings
+- Spring bounce reversed: 3,645 jobs (-7.5% MoM)—second-lowest in tracking, all three platforms declined
+- Rates reverted: $39.46/hr (-3.0% from March)—back below $40, 12-month round-trip complete
+- n8n total growth flipped negative: -14.5% MoM, -5.1% since May (first negative total in tracking history)
+- GoHighLevel resilient: 687 jobs (-0.9% MoM)—held near all-time high in -7.5% market
+- All four dedicated CRMs positive since May: First time. Salesforce +17.2%, GoHighLevel +22.5%, Zoho +15.5%, HubSpot +13.2%
+- Salesforce recovery confirmed: +15.9% MoM, second consecutive recovery month
+- Zoho rebound: +17.8% MoM, total flipped positive (+15.5% since May)
+- Make.com recovery stalled: -3.1% MoM, ending two-month positive streak
+- AI/Claude engineering as new premium ceiling: $200-500/hr work concentrated at the top tier
+- Premium tier contracted: 139 jobs at $75+ (3.8% share)—lowest count since November, expert tier -25%
+- Excel worst total decline: -52.4% since May—now half of May volume
+
+
 ## [0.11.0] - 2026-04-02
 ### Added
 - upwork-analysis/app-comparison-march-2026.md

--- a/upwork-analysis/app-comparison-april-2026.md
+++ b/upwork-analysis/app-comparison-april-2026.md
@@ -1,0 +1,325 @@
+# Upwork Automation Market: Platform & Application Comparison
+## April 2026 Analysis
+
+**Report Date:** May 2026
+**Data Period:** May 2025 - April 2026 (12 months)
+**Total Jobs Analyzed:** 53,786
+
+---
+
+## Executive Summary
+
+April 2026 reversed the spring bounce. Volume contracted to 3,645 jobs (-7.5% MoM)—the second-lowest count in 12 months of tracking, just above February's tracking low of 3,690. After March's broad-based growth (all three platforms simultaneously up), April delivered broad-based decline: Zapier -2.3%, n8n -14.5%, Make.com -3.1%. Average rates corrected further to **$39.46/hr** (-3.0% from March), falling back below the $40 threshold that February-March had appeared to establish as a structural floor.
+
+The headline stories: **n8n's recovery undone**—the platform shed 213 jobs (-14.5% MoM), with total growth since May flipping from +11.0% to -5.1%, the first time total growth has gone negative since tracking began. **GoHighLevel held its near-record level** at 687 jobs (-0.9% MoM), demonstrating CRM demand resilience. **High-paying opportunities contracted** to 139 jobs at $75+/hr, the lowest count since December and matching November's low. **Salesforce and Zoho rebounded** (+15.9% and +17.8% respectively) as the CRM rotation continued.
+
+**Key April Insight:** The "structural shift above $40/hr" narrative needs revision. Two months at $40-43/hr were a Q1 anomaly, not a new floor. April's $39.46 sits squarely in the May-October range. Volume softness suggests the Q1 budget cycle has cleared and the market is returning to its 2025 baseline pattern. The bull case rests on GoHighLevel's resilience and AI work driving premium rates, but the broad market is contracting.
+
+---
+
+## Platform Comparison: Twelve-Month Evolution
+
+### Major Automation Platforms
+
+| Platform | May | June | July | Aug | Sept | Oct | Nov | Dec | Jan | Feb | Mar | Apr | Mar MoM | Total Growth |
+|----------|-----|------|------|-----|------|-----|-----|-----|-----|-----|-----|-----|---------|--------------|
+| **Zapier** | 2,236 | 2,554 | 2,796 | 2,663 | 2,233 | 2,132 | 1,662 | 1,753 | 1,767 | 1,721 | 1,827 | 1,785 | 🟡 -2.3% | 📉 -20.2% |
+| **n8n** | 1,319 | 1,794 | 1,984 | 2,155 | 2,099 | 2,024 | 1,729 | 1,663 | 1,535 | 1,403 | 1,465 | 1,252 | 💥 -14.5% | 📉 -5.1% |
+| **Make.com** | 1,143 | 1,278 | 1,429 | 1,174 | 967 | 1,027 | 811 | 751 | 725 | 743 | 806 | 781 | 🟡 -3.1% | 📉 -31.7% |
+| **Power Automate** | 29 | 30 | 28 | 47 | 33 | 42 | 20 | 28 | 37 | 22 | 29 | 30 | 🟢 +3.4% | 🟢 +3.4% |
+
+**Status Indicators:**
+- 🚀 Strong Growth (>10%)
+- 🟢 Stable/Growth (0-10%)
+- 🟡 Slight Decline (0-5%)
+- 📉 Declining (>5%)
+- 💥 Collapse (>10% single month or >20% total)
+
+### Platform Analysis
+
+**Zapier (Quiet Decline)**
+- Current: 1,785 jobs (47.0% market share)
+- Trend: -2.3% MoM, giving back most of March's +6.1% gain
+- Total: -20.2% since May, worst total drawdown since tracking
+- Assessment: Maintains dominance but absolute volume continues to erode
+- Recommendation: Still primary platform; specialization more important than ever
+
+**n8n (Recovery Reversed)**
+- Current: 1,252 jobs (33.0% market share)
+- Trend: -14.5% MoM, **largest single-month decline of any major platform in 2026**
+- Total: **-5.1% since May (first negative total growth in tracking history)**
+- Assessment: March's +4.3% bounce now looks like a dead-cat bounce
+- Recommendation: Premium positioning intact, but the platform's total trajectory has flipped negative
+
+**Make.com (Recovery Stalled)**
+- Current: 781 jobs (20.6% market share)
+- Trend: -3.1% MoM, ending the two-month recovery (+2.5%, +8.1%)
+- Total: -31.7% since May, still the worst total decline among major platforms
+- Assessment: Recovery thesis weakened; needs Q2 stabilization to confirm structural floor
+- Recommendation: Viable secondary platform; do not over-allocate
+
+**Power Automate (Tiny but Stable)**
+- Current: 30 jobs
+- Trend: +3.4% MoM, +3.4% since May
+- Total: Effectively flat across 12 months
+- Assessment: Niche enterprise tool, not a meaningful share of market
+- Recommendation: Microsoft enterprise ecosystem only
+
+---
+
+## Application Ecosystem: April 2026
+
+### Top 15 Applications by Job Volume
+
+| Application | May | June | July | Aug | Sept | Oct | Nov | Dec | Jan | Feb | Mar | Apr | Mar MoM | Total | Status |
+|-------------|-----|------|------|-----|------|-----|-----|-----|-----|-----|-----|-----|---------|-------|--------|
+| **GoHighLevel** | 561 | 647 | 682 | 647 | 662 | 659 | 579 | 562 | 645 | 585 | 693 | 687 | 🟡 -0.9% | 🚀 +22.5% | **Holding near all-time high** |
+| **Google Sheets** | 786 | 931 | 984 | 815 | 719 | 726 | 597 | 552 | 537 | 495 | 526 | 532 | 🟢 +1.1% | 📉 -32.3% | Stabilizing |
+| **Airtable** | 666 | 779 | 916 | 731 | 604 | 611 | 505 | 492 | 467 | 424 | 435 | 447 | 🟢 +2.8% | 📉 -32.9% | Mild bounce |
+| **HubSpot** | 334 | 396 | 412 | 490 | 450 | 447 | 346 | 333 | 350 | 349 | 375 | 378 | 🟢 +0.8% | 🚀 +13.2% | **Stable strength** |
+| **Slack** | 482 | 485 | 625 | 519 | 460 | 461 | 354 | 321 | 307 | 316 | 336 | 323 | 🟡 -3.9% | 📉 -33.0% | Slight pullback |
+| **Excel** | 494 | 564 | 602 | 626 | 549 | 568 | 403 | 382 | 316 | 280 | 251 | 235 | 📉 -6.4% | 💥 -52.4% | **Worst total decline** |
+| **Notion** | 433 | 537 | 592 | 483 | 325 | 414 | 321 | 341 | 273 | 243 | 229 | 230 | 🟢 +0.4% | 📉 -46.9% | Floor reached? |
+| **Monday.com** | 108 | 133 | 141 | 125 | 98 | 97 | 101 | 90 | 102 | 101 | 104 | 111 | 🟢 +6.7% | 🟢 +2.8% | Stable, slight growth |
+| **Zoho** | 103 | 113 | 175 | 163 | 124 | 141 | 128 | 122 | 82 | 120 | 101 | 119 | 🚀 +17.8% | 🚀 +15.5% | **Rebound** |
+| **Salesforce** | 87 | 121 | 110 | 146 | 149 | 106 | 81 | 96 | 88 | 110 | 88 | 102 | 🚀 +15.9% | 🚀 +17.2% | Recovery |
+| **ClickUp** | 195 | 186 | 251 | 199 | 166 | 182 | 135 | 169 | 146 | 134 | 112 | 103 | 📉 -8.0% | 💥 -47.2% | Continued decline |
+| **QuickBooks** | 72 | 112 | 108 | 123 | 93 | 95 | 79 | 64 | 77 | 73 | 94 | 95 | 🟢 +1.1% | 🚀 +31.9% | **Strongest total growth** |
+| **Asana** | 80 | 99 | 92 | 100 | 93 | 97 | 67 | 71 | 64 | 65 | 49 | 72 | 🚀 +46.9% | 🟡 -10.0% | Sharp bounce |
+| **Trello** | 75 | 87 | 94 | 78 | 75 | 55 | 48 | 47 | 26 | 24 | 31 | 41 | 🚀 +32.3% | 💥 -45.3% | Bounce, still depressed |
+| **Xero** | 35 | 44 | 60 | 58 | 43 | 51 | 40 | 34 | 30 | 37 | 43 | 42 | 🟡 -2.3% | 🚀 +20.0% | Sustained growth |
+
+---
+
+## CRM Platform Deep Dive
+
+### Dedicated CRM Systems
+
+| CRM | May | March | April | Mar→Apr | Total Growth | Market Assessment |
+|-----|-----|-------|-------|---------|--------------|-------------------|
+| **GoHighLevel** | 561 | 693 | 687 | -0.9% | +22.5% | **Held near all-time high, dominant CRM** |
+| **HubSpot** | 334 | 375 | 378 | +0.8% | +13.2% | **Stable strength, double-digit total growth** |
+| **Zoho** | 103 | 101 | 119 | +17.8% | +15.5% | Strong rebound, total growth flipped positive |
+| **Salesforce** | 87 | 88 | 102 | +15.9% | +17.2% | Recovery confirmed, second consecutive surge |
+
+**Key Insight:** April 2026 was the strongest month for dedicated CRMs since tracking began. While the broad market contracted -7.5%, all four tracked CRMs were either flat or up. **All four CRMs now show double-digit total growth since May**—the first time this has happened. The CRM rotation continues: March's losers (Salesforce, Zoho) became April's winners. GoHighLevel's resilience (-0.9% in a -7.5% market) confirms agency demand structural strength. HubSpot's quiet stability (+0.8%) maintains its strongest year-over-year position.
+
+### Generic "CRM" Mentions
+
+| Month | Mentions | Change |
+|-------|----------|--------|
+| May | 1,202 | Baseline |
+| March | 1,436 | All-time high |
+| April | 1,379 | -4.0% MoM, +14.7% since May |
+
+Generic CRM mentions pulled back -4.0% from March's all-time high but remain +14.7% above May baseline. CRM demand pulled back less than total volume (-7.5%), reinforcing CRM as the most resilient sub-category.
+
+### Alternative CRM Solutions
+
+| Application | May | April | Change | Assessment |
+|-------------|-----|-------|--------|------------|
+| **Airtable** | 666 | 447 | -32.9% | Mild bounce, structural decline intact |
+| **Notion** | 433 | 230 | -46.9% | Floor possibly reached after months of decline |
+| **ClickUp** | 195 | 103 | -47.2% | Continued decline, near half its May volume |
+| **Monday.com** | 108 | 111 | +2.8% | **Most stable alternative, slightly positive** |
+
+**Combined Alternative CRMs:** 891 jobs (April) vs 1,402 jobs (May) = -36.4%
+
+**Insight:** Alternative CRMs as a category remain in structural decline, down -36.4% from May. The dedicated CRM vs. alternative CRM gap has now widened to ~12-month highs: dedicated CRMs +17.6% combined, alternatives -36.4%. Monday.com remains the only alternative that has maintained or grown its volume. Notion's flat April (+0.4%) may indicate a floor; ClickUp shows no such signs.
+
+---
+
+## April Market Dynamics
+
+### Volume Contracts to Near-Tracking-Low
+
+**Volume Trends:**
+- July Peak: 5,522 jobs
+- February Low: 3,690 jobs
+- March Bounce: 3,939 jobs (+6.7% MoM)
+- April: 3,645 jobs (-7.5% MoM, **second-lowest in tracking**)
+
+**Assessment:** March's spring bounce was not the start of a recovery. April's decline brings the market back near February's tracking low. The 12-month total decline from May is now -14.4%, the largest cumulative drawdown of the analysis period. The Q1 budget surge has clearly cleared.
+
+### Rate Falls Below $40 Threshold
+
+| Month | Avg Rate | High-Paying Count ($75+) | Premium Share | Trend |
+|-------|----------|--------------------------|---------------|-------|
+| May | $39.10/hr | 153 | 3.6% | Baseline |
+| December | $37.58/hr | 144 | 3.7% | Rate trough |
+| January | $40.20/hr | 165 | 4.2% | First all-time high |
+| February | $43.27/hr | 170 | 4.6% | Second all-time high |
+| March | $40.66/hr | 167 | 4.2% | Correction from peak |
+| April | $39.46/hr | 139 | 3.8% | **Below $40 threshold** |
+
+**Analysis:** April's $39.46 falls back into the May-October $38-40 range. The "structural shift above $40/hr" narrative does not survive April's data. The Jan-Feb surge appears to have been driven by Q1 budget cycles and AI premium spillover; April's correction completes the round-trip toward 2025 baseline. High-paying jobs ($75+) at 139 match November's low. Premium share (3.8%) is the lowest since November.
+
+### Platform Leadership: All Three Declined
+
+**All Three Platforms Declined**
+
+| Platform | March | April | Share Change |
+|----------|-------|-------|-------------|
+| Zapier | 1,827 (46.4%) | 1,785 (47.0%) | +0.6 pts |
+| n8n | 1,465 (37.2%) | 1,252 (33.0%) | -4.2 pts |
+| Make.com | 806 (20.5%) | 781 (20.6%) | +0.1 pts |
+
+n8n was the biggest casualty—losing 213 jobs and shedding 4.2 percentage points of share. Zapier gained share by declining less. Make.com's share held flat. The market's center of gravity is shifting back toward Zapier.
+
+### April Winners and Losers
+
+**Applications with April MoM Growth:**
+- Asana: +46.9% (72 jobs)—sharp rebound from March's 49-job low (still -10.0% total)
+- Trello: +32.3% (41 jobs)—continued bounce from near-extinction (still -45.3% total)
+- Zoho: +17.8% (119 jobs)—CRM rotation favor, total growth flipped positive (+15.5%)
+- Salesforce: +15.9% (102 jobs)—second consecutive recovery month
+- Monday.com: +6.7% (111 jobs)—most stable alternative, slight growth
+- Airtable: +2.8% (447 jobs)—small bounce, structural decline intact
+- Google Sheets: +1.1% (532 jobs)—stabilizing
+- HubSpot: +0.8% (378 jobs)—essentially flat at strong level
+- QuickBooks: +1.1% (95 jobs)—holding near 12-month high
+- Notion: +0.4% (230 jobs)—possible floor
+
+**Applications with April Declines:**
+- ClickUp: -8.0% (103 jobs)—continued structural decline
+- Excel: -6.4% (235 jobs)—-52.4% total, worst tracked
+- Slack: -3.9% (323 jobs)—slight pullback from March's bounce
+- Xero: -2.3% (42 jobs)—Q1 accounting demand normalizing
+- GoHighLevel: -0.9% (687 jobs)—essentially flat near all-time high
+
+---
+
+## Strategic Recommendations
+
+### Platform Strategy for Q2 2026
+
+**1. Zapier: Defensive Leader**
+- 1,785 jobs (47.0% market share, share gaining via others' declines)
+- -2.3% MoM, but most stable in absolute terms
+- Total -20.2% since May—worst absolute drawdown across full year
+
+**Recommendation:** Primary platform; volume cushion remains, but watch for further share consolidation
+
+**2. n8n: Recovery Failed**
+- 1,252 jobs (33.0% share), now -5.1% since May
+- -14.5% in April erases March's bounce and more
+- First negative total growth in tracking history
+
+**Recommendation:** Premium niche intact (technical depth still pays), but the broad-market n8n thesis has weakened. Pair with CRM specialization to insulate from platform volatility.
+
+**3. Make.com: Recovery Stalled**
+- 781 jobs (20.6% share), -3.1% MoM ending two-month recovery
+- -31.7% total since May, still worst major-platform total decline
+
+**Recommendation:** Secondary platform only; the structural recovery thesis needs another month of confirmation before commitment
+
+**4. CRM Rotation: All Four Now Positive Since May**
+- GoHighLevel +22.5% since May (687 jobs, near all-time high)
+- HubSpot +13.2% since May (378 jobs, stable strength)
+- Salesforce +17.2% since May (102 jobs, recovery confirmed)
+- Zoho +15.5% since May (119 jobs, total growth flipped positive)
+
+**Recommendation:** CRM specialization is the strongest sub-segment. All four dedicated CRMs now show double-digit total growth—first time this has happened across 12 months.
+
+### Application Strategy
+
+**High-Value Specializations:**
+
+1. **CRM + Automation Specialist** ($75-200/hr)
+   - All four dedicated CRMs positive since May (first time)
+   - GoHighLevel held near all-time high while broad market contracted -7.5%
+   - Generic CRM mentions still +14.7% above May baseline
+
+2. **AI / Claude Engineering** ($150-500/hr)
+   - April premium tier dominated by AI work: $500/hr Claude AI Engineer, $300/hr n8n+OpenClaw, $250/hr Claude Senior Helpers
+   - AI integration is the clearest premium driver
+
+3. **Accounting Automation** ($60-120/hr)
+   - QuickBooks holding +31.9% since May (strongest total growth)
+   - Xero +20.0% total despite April pullback
+
+4. **Multi-CRM Migration** ($80-150/hr)
+   - Salesforce/Zoho rebounds suggest enterprise CRM rotation continues
+   - Migration projects remain steady
+
+**Avoid/Deprioritize:**
+- Excel-only: -52.4% since May (235 jobs)—now half of May volume
+- ClickUp-only: -47.2% since May (103 jobs)—accelerating erosion
+- Notion-only: -46.9% since May (230 jobs)—possible floor but no recovery signal
+- Trello: -45.3% since May (41 jobs)—bouncing in single digits, not material
+- Generalist platform-only positioning: market punishes lack of CRM/AI specialization
+
+### Rate Strategy for Q2 2026
+
+**Current Market:**
+- Average: $39.46/hr (back below $40 threshold)
+- High-paying jobs ($75+): 139 (3.8% of market, lowest share since November)
+- Ultra-premium ($150+): ~17 jobs
+- Max rate: $500/hr (lower than previous months' $999 max)
+
+**Positioning:**
+- **Entry:** $25-40/hr (avoid—market still compressing here)
+- **Experienced:** $50-75/hr (requires specialization to compete)
+- **Specialist:** $75-130/hr (CRM + platform + industry/AI)
+- **Premium:** $130-300/hr (AI/Claude + technical depth)
+- **Ultra-Premium:** $300-500/hr (AI agent architecture, autonomous systems)
+
+**Key:** Two months at $40-43/hr were a Q1 anomaly, not a new floor. April's $39.46 reverts to the 2025 baseline range. Premium pricing now requires more specialization than it did in February.
+
+---
+
+## Q2 2026 Outlook
+
+### Expected May-July Trends
+
+1. **Volume:** Likely 3,500-3,900 range; February-April formed a clear new band well below summer 2025
+2. **Rates:** $38-40/hr likely the new normal; only specialists capture $75+
+3. **GoHighLevel resilience:** Watch April's near-flat as confirmation of agency demand floor
+4. **n8n trajectory:** Without a May rebound, the negative-total-growth narrative hardens
+5. **Make.com:** Two more months will determine if the recovery thesis survives
+6. **CRM rotation:** Salesforce/Zoho recovery continues; HubSpot stability persists
+7. **AI premium tier:** $250-500/hr work concentrated in AI/Claude engineering
+
+### Market Structure Evolution
+
+**What's Happened (12 months):**
+- Market contracted -14.4% from May baseline (-34.0% from July peak)
+- Average rates round-tripped: started $39.10, peaked $43.27, now $39.46
+- CRM demand outperforms all other categories (all four CRMs positive since May)
+- n8n total growth flipped negative for first time (-5.1%)
+- All three platforms ended Q1 with declining share or volume
+- Premium market share contracting (4.6% in Feb → 3.8% in April)
+
+**What's Next:**
+- Q2 baseline likely 3,500-3,900 monthly jobs at $38-40/hr
+- CRM specialization remains the highest-margin niche
+- AI/Claude premium tier replacing generic AI work
+- Platform-only positioning increasingly punished
+- Migration and consolidation work as recurring revenue streams
+
+---
+
+## Methodology
+
+**Data Source:** Upwork job export CSVs (May 2025-April 2026)
+**Analysis Method:** Keyword search in job titles and descriptions (substring matching)
+**Platform Keywords:** "Zapier", "Make.com"/"Integromat", "n8n", "Power Automate"
+**Application Keywords:** Specific product names in job descriptions
+**Rate Calculation:** Average of hourly maximum rates where provided
+
+**Limitations:**
+- Jobs may mention multiple platforms (overlap exists)
+- Generic automation jobs without platform mentions excluded
+- Rates are posted maximums, not actual contracted rates
+- Sample represents Upwork marketplace only
+- Substring matching may catch incidental mentions (e.g., "excel" in "excellent")
+
+---
+
+**Report Generated:** May 2026
+**Next Update:** May 2026 data (expected June 2026)
+**Questions/Feedback:** Via GitHub Issues
+
+---
+
+*This analysis is part of the ongoing Upwork Automation Market Analysis project tracking the evolution of the automation consulting marketplace.*

--- a/upwork-analysis/high-paying-guide-april-2026.md
+++ b/upwork-analysis/high-paying-guide-april-2026.md
@@ -1,0 +1,641 @@
+# High-Paying Automation Opportunities Guide
+## April 2026 Market Analysis
+
+**Report Date:** May 2026
+**Data Period:** May 2025 - April 2026
+**High-Paying Jobs Tracked:** 139 jobs at $75+/hr in April
+
+---
+
+## Executive Summary
+
+April 2026 reversed the spring rate gains. **High-paying opportunities contracted to 139 jobs at $75+/hr** (down from March's 167)—the lowest count since November and matching the Nov-Dec trough. Average rates fell to $39.46/hr (-3.0% from March), back below the $40 threshold that February-March had appeared to establish. The premium market share (3.8%) is the lowest since November 2025.
+
+The market contracted broadly: total volume declined -7.5% to 3,645 jobs (second-lowest in tracking), all three major platforms shed volume, and high-paying opportunities fell -16.8% MoM. The bull case has narrowed: **AI/Claude engineering work now dominates the ultra-premium tier** ($250-500/hr), while traditional platform expertise has compressed back toward $75-100.
+
+**Bottom Line:** February's $43.27 was a Q1 peak, not a structural shift. April's $39.46 confirms the round-trip back to the 2025 baseline range. Premium positioning still works—but increasingly requires AI specialization, not just platform mastery. The 139 high-paying jobs are still a viable target market for specialists, but the broad expansion of premium share has reversed.
+
+---
+
+## Rate Tiers & Market Reality
+
+### April 2026 Rate Breakdown
+
+| Tier | Rate Range | Jobs Available | Requirements | Market Trend |
+|------|------------|----------------|--------------|--------------|
+| **Ultra-Premium** | $150-500/hr | 19 jobs | AI/Claude + autonomous systems + industry | Concentrated in AI work |
+| **Premium** | $100-150/hr | 49 jobs | Multi-platform + CRM + AI integration | **Contracted from 57** |
+| **Expert** | $75-100/hr | 71 jobs | Platform certified + CRM + proven results | **Contracted from 95** |
+| **Experienced** | $50-75/hr | 234 jobs | Multi-platform competency | Stable |
+| **Mid-Tier** | $40-50/hr | 202 jobs | Single platform proficiency | Stable |
+| **Entry** | $25-40/hr | 426 jobs | Basic automation tasks | Compressing |
+
+**Key Insight:** April's premium contraction is broad-based across all three premium tiers. Ultra-premium ($150+) held at 19 (vs 15 in March), but the expert tier dropped sharply from 95 to 71 jobs (-25%). The premium market is consolidating at the very top (AI work) and bottom (entry-level), with the middle tiers thinning. Premium share at 3.8% matches November's low.
+
+### Average Rate Evolution
+
+| Month | Market Average | High-Paying Count ($75+) | Premium Share | Trend |
+|-------|----------------|--------------------------|---------------|-------|
+| May | $39.10/hr | 153 | 3.6% | Baseline |
+| July | $39.61/hr | 214 | 3.9% | Peak volume |
+| November | $38.79/hr | 139 | 3.3% | Trough |
+| December | $37.58/hr | 144 | 3.7% | Rate floor |
+| January | $40.20/hr | 165 | 4.2% | First all-time high |
+| February | $43.27/hr | 170 | 4.6% | Second all-time high |
+| March | $40.66/hr | 167 | 4.2% | Correction from peak |
+| April | $39.46/hr | 139 | 3.8% | **Back below $40** |
+
+**Analysis:** The 12-month round-trip is now complete. April's $39.46 sits squarely in the May-October $38-40 range. The Jan-Feb surge appears to have been a Q1 budget-cycle event compounded by AI premium spillover; without those tailwinds, the market reverts to its 2025 baseline. The structural-shift-above-$40 narrative does not survive April's data.
+
+---
+
+## Ultra-Premium Opportunities ($150-500/hr)
+
+### Profile Requirements
+
+**Technical Stack:**
+- Claude/OpenAI API mastery (autonomous agents, complex prompt engineering)
+- AI agent architecture (multi-step reasoning, tool use, memory systems)
+- n8n or Zapier (technical depth, workflow orchestration)
+- Voice AI (Retell, Vapi—still emerging)
+- Custom development (Python, TypeScript, Node.js)
+- Self-hosted infrastructure (Docker, Kubernetes, observability)
+
+**Industry Knowledge:**
+- Senior care / home health (e.g., Senior Helpers franchise networks)
+- Real estate / property management (AI growth strategy, fractional CMO)
+- AI-native businesses (autonomous business agents, AI-operated companies)
+- Construction estimating (AI + Make.com + Airtable systems)
+- Financial services (compliance + AI integration)
+
+**Proven Track Record:**
+- Production AI agent deployments
+- $50K+ project portfolio
+- Quantified business outcomes
+- Published technical thought leadership
+- Active GitHub or content presence
+
+### April Market Reality
+
+Ultra-premium opportunities concentrated heavily in AI/Claude work in April. Of the top 10 highest-rate jobs:
+- 5 explicitly mention Claude AI or AI agents
+- 3 are CRM/automation architecture for high-value verticals
+- 2 are growth-strategy / fractional executive roles
+
+**Entry Barrier:** Very high—requires production-grade AI agent experience, not just API integration. The premium tier has shifted from "AI-enhanced automation" to "AI-native systems engineering."
+
+### Actual April Examples
+
+**Example 1: Claude AI Engineer for Autonomous Business Agents**
+- Rate: **$500/hr**
+- Requirements: High-level Claude AI engineer to build autonomous AI-operated company
+- Project: Acquisitions.com building fully AI-operated business
+- Context: Highest single rate observed in April; AI agent architecture as standalone premium tier
+
+**Example 2: N8N + OpenClaw Specialist for AI Agent Deployments**
+- Rate: **$300/hr**
+- Requirements: N8N + OpenClaw expert, complex workflow orchestration, AI agent deployments
+- Project: Technical build-out for businesses applying AI
+- Context: n8n's premium positioning persists at the top of the rate stack despite broad-market decline
+
+**Example 3: Claude AI for Senior Helpers Franchise Operating System**
+- Rate: **$250/hr**
+- Requirements: Claude AI engineer, multi-system orchestration, home care domain
+- Project: Build "Master Operating System" for Senior Helpers franchise (Hamilton County, OH)
+- Context: Industry-vertical AI agent work commands premium
+
+**Example 4: Airtable CRM Integration Specialist**
+- Rate: **$200/hr**
+- Requirements: Airtable expertise, CRM component integration
+- Project: Embed CRM into existing Airtable workspace
+- Context: Airtable as premium niche when paired with CRM strategy work
+
+**Example 5: Make.com + Airtable + OpenAI Construction Estimating**
+- Rate: **$175/hr**
+- Requirements: Make.com automation, Airtable, OpenAI integration, construction domain
+- Project: AI-powered estimating system for high-end custom home builder (Texas)
+- Context: Industry-specific AI automation continues to command premium
+
+---
+
+## Premium Opportunities ($100-150/hr)
+
+### Profile Requirements
+
+**Core Competencies:**
+- Deep expertise in one platform + working knowledge of a second
+- CRM specialization (GoHighLevel held near all-time high; HubSpot stable)
+- AI integration (production API work, not just chat)
+- Industry-specific positioning
+- Strategic consulting beyond implementation
+
+**Differentiators:**
+- Published case studies with quantified ROI
+- Platform certifications (n8n, HubSpot, Zapier, Salesforce)
+- Visible thought leadership (LinkedIn, YouTube, blog)
+- Proprietary frameworks or templates
+- Strong client references and repeat business
+
+### April High-Demand Segments
+
+#### 1. GoHighLevel Agency Automation ($100-150/hr)
+
+**Opportunity:** 687 jobs—holding near all-time high (-0.9% MoM in a -7.5% market)
+
+**Skills Needed:**
+- GoHighLevel platform mastery (workflows, CRM, funnels, snapshots)
+- n8n or Zapier for external integrations
+- Marketing automation and funnel optimization
+- White-label solution development
+- Agency workflow consulting
+
+**Why Premium:** GoHighLevel's resilience during a contracting market is the strongest signal in the April data. Agency demand is structurally insulated from broader market softness. Rate ranges held steady between $100-150/hr.
+
+**April Insight:** GoHighLevel at 687 jobs while broad market shed -7.5% means GHL's relative share grew. Agencies are still investing.
+
+#### 2. AI/Claude Engineering ($120-300/hr+)
+
+**Opportunity:** Premium tier increasingly dominated by AI-native work
+
+**Skills Needed:**
+- Claude API mastery (tool use, agentic systems, memory)
+- OpenAI API and prompt engineering
+- LangChain or similar agent frameworks
+- Vector databases and RAG architecture
+- Production deployment (latency, reliability, cost optimization)
+
+**Why Premium:** April's top 10 highest-rate jobs were dominated by AI/Claude engineering. The premium tier has shifted from "platform + AI integration" to "AI-native systems engineering." Generic AI-enhanced workflows now sit at $75-100/hr; standalone AI agent architecture commands $200-500/hr.
+
+#### 3. Multi-CRM Integration ($100-150/hr)
+
+**Opportunity:** All four dedicated CRMs positive since May (first time in tracking)
+
+**Skills Needed:**
+- Deep expertise in one CRM (GoHighLevel, HubSpot, Salesforce, or Zoho)
+- Migration tooling and data quality expertise
+- Multi-system orchestration
+- Industry-specific CRM configuration
+- Reporting and analytics integration
+
+**Why Premium:** April's CRM rotation favored Salesforce (+15.9%) and Zoho (+17.8%). Migration and consolidation work between CRMs continues to command premium rates.
+
+#### 4. n8n Technical Specialist ($100-150/hr)
+
+**Opportunity:** 1,252 jobs—down -14.5% MoM, but still the second-largest platform
+
+**Skills Needed:**
+- n8n self-hosting (Docker, custom nodes, scaling)
+- Claude/GPT API integration with n8n workflows
+- Complex workflow architecture
+- AI agent and orchestration
+- Custom automation consulting
+
+**Why Premium:** n8n's broad-market decline doesn't extend to the technical premium tier. Complex n8n + AI work still commands $125-300/hr (see $300/hr OpenClaw example). The platform's enthusiast base remains willing to pay for technical depth.
+
+**April Caution:** With total growth flipped negative (-5.1% since May), pair n8n specialization with CRM or industry positioning to insulate from platform-level volatility.
+
+---
+
+## Expert Tier Opportunities ($75-100/hr)
+
+### Profile Requirements
+
+**Core Skills:**
+- Deep expertise in one platform OR
+- Competency in two platforms
+- 50+ completed automations
+- Industry-specific knowledge
+- Project management capabilities
+
+**Minimum Credentials:**
+- 10+ client references
+- Platform certification
+- Public portfolio with case studies
+
+### Resilient Segments
+
+#### 1. Accounting Automation ($75-100/hr)
+
+**Opportunity:** QuickBooks (95 jobs, +31.9% since May), Xero (42 jobs, +20.0% since May)
+
+**Focus:**
+- QuickBooks + Zapier/Make.com integration
+- Xero automation workflows
+- Financial reporting automation
+- Invoice and payment processing
+- Tax season workflow optimization
+
+**Why Growing:** QuickBooks holding near 12-month high. Accounting automation delivers measurable ROI; demand is structurally insulated.
+
+#### 2. CRM Implementation ($75-100/hr)
+
+**Opportunity:** All four dedicated CRMs positive since May
+
+**Focus:**
+- HubSpot configuration and onboarding
+- GoHighLevel agency setup
+- Salesforce admin and customization
+- Zoho implementation
+- CRM data migration
+
+**Why Stable:** CRM demand is the most resilient sub-segment. Even in April's contraction, CRMs as a category grew while other categories shed volume.
+
+#### 3. E-Commerce Automation ($75-95/hr)
+
+**Opportunity:** Shopify + subscription management, Klaviyo email automation
+
+**Focus:**
+- Shopify + automation platforms
+- Subscription management (Recharge, Chargebee)
+- Inventory and fulfillment workflows
+- Multi-channel synchronization
+- Klaviyo segmentation and flows
+
+**Why Stable:** Subscription economics drive ongoing automation investment.
+
+#### 4. Zapier Advanced Implementation ($75-100/hr)
+
+**Opportunity:** 1,785 jobs—Zapier remains dominant (47.0% share)
+
+**Focus:**
+- Zapier Tables and Interfaces
+- Complex multi-step workflows
+- Error handling and monitoring
+- Zapier for Teams deployment
+- Migration from legacy automation
+
+**Why Relevant:** Zapier's share grew in April through others' declines. Steady volume of advanced implementation work.
+
+---
+
+## Navigating the Volume Contraction
+
+### April Market Reality
+
+**Market Status:**
+- Total jobs: 3,645 (-7.5% MoM, second-lowest in tracking)
+- Average rate: $39.46/hr (back below $40, in 2025 baseline range)
+- High-paying jobs: 139 (-16.8% from March, 3.8% share)
+- Ultra-premium ($150+): 19 jobs
+- Expert tier ($75-100): 71 jobs (down from 95 in March)
+- Max rate: $500/hr (Claude AI Engineer)
+
+**What This Means:**
+- Premium share is contracting (4.6% Feb → 3.8% April)
+- Expert tier ($75-100) lost the most jobs (-25% MoM)
+- Ultra-premium tier holding via concentrated AI work
+- The Jan-Feb rate surge was Q1-driven, not structural
+- Volume softness suggests Q2 budget pull-back
+
+### The Round-Trip is Complete
+
+**12-Month Rate Journey:**
+- May: $39.10/hr (baseline)
+- December: $37.58/hr (trough)
+- February: $43.27/hr (peak)
+- April: $39.46/hr (round-trip)
+
+**Implication:** The market is in equilibrium near $39-40/hr. The premium tier still exists but commands a smaller share. For specialists, this means: rates are sustainable but no longer expanding; the path to premium is narrower (AI/Claude work) and more competitive.
+
+### The New Premium Map
+
+**Concentrated (~25% of premium tier):**
+- AI/Claude engineering ($200-500/hr)
+- Industry-vertical AI agents ($150-300/hr)
+- Autonomous systems architecture ($250-500/hr)
+
+**Stable (~50% of premium tier):**
+- CRM specialists ($75-150/hr) — all four CRMs positive since May
+- GoHighLevel agency automation ($100-150/hr)
+- HubSpot enterprise marketing ($90-140/hr)
+- Multi-platform integration ($75-130/hr)
+
+**Compressing (~25% of premium tier):**
+- Generic platform expertise ($75-100/hr)
+- Single-platform specialists without CRM/AI overlay
+- Make.com-only positioning
+
+### Action Plan
+
+#### If Revenue Growing: Lean Into AI
+
+**Immediate:**
+1. Audit current positioning for AI-native opportunities
+2. Build a Claude or OpenAI agent demo project
+3. Target ultra-premium AI work ($150-300/hr) selectively
+4. GoHighLevel held near all-time high—deepen if you have the relationship
+
+**Q2 Strategy:**
+1. Position as AI agent architect, not just automation builder
+2. Develop industry-specific case studies (April's premium work was vertical)
+3. Build retainer relationships with Q1 clients before Q2 budget cycle
+4. Create thought leadership content around AI/automation intersection
+
+#### If Revenue Stable: Hold Rates, Specialize Deeper
+
+**Actions:**
+1. Rates at $39.46 average mean discipline matters—don't chase volume by discounting
+2. Premium share is contracting—specialization is the moat
+3. Add CRM specialization if not already (all four positive since May)
+4. Pair platform expertise with one industry vertical
+
+**Goal:** Maintain $75+/hr positioning even as the broad market compresses
+
+#### If Revenue Down: Volume Strategy with Specialization
+
+**Immediate:**
+1. Volume is contracting—proposal volume must increase
+2. Target $50-75/hr range (234 jobs) with specialization narrative
+3. Add accounting automation (QuickBooks +31.9% since May, holding strong)
+4. Complete CRM certification (GoHighLevel, HubSpot, or Salesforce)
+
+**30-Day Plan:**
+1. Complete one CRM certification
+2. Build 2 AI-enhanced automation portfolio projects
+3. Target 25+ proposals per week (volume to compensate for market contraction)
+4. Apply to $50-75/hr range with strong specialization positioning
+
+---
+
+## Rate Optimization Strategies
+
+### 1. Reposition Around AI Agent Architecture
+
+**Strategy:** The premium ceiling has shifted from "AI integration" to "AI-native systems"
+
+**Before:** "Automation specialist with AI integration experience"
+**After:** "AI agent architect — I design and deploy autonomous business systems"
+
+**Tactics:**
+- Build a Claude tool-use demo (multi-step reasoning, tool calling)
+- Document a production AI agent deployment with metrics
+- Master one agent framework deeply (LangChain, custom Claude agents)
+- Position around outcomes (autonomous workflows, decision agents)
+
+**Rate Impact:** +50-100% positioning premium for AI-native vs generic AI-enhanced
+
+### 2. CRM + Industry Stacking
+
+**Strategy:** All four dedicated CRMs positive since May—pair CRM with one industry
+
+**Before:** "GoHighLevel specialist"
+**After:** "GoHighLevel implementation lead for [agency/services/real estate]"
+
+**Tactics:**
+- GoHighLevel for digital marketing agencies (687 jobs, near all-time high)
+- HubSpot for B2B SaaS (378 jobs, stable strength)
+- Salesforce for enterprise services (102 jobs, recovery confirmed)
+- Industry framing creates pricing power
+
+**Rate Impact:** +30-50% for industry-specific CRM positioning
+
+### 3. Value-Based Pricing for Stability
+
+**Strategy:** Decouple rates from market hourly compression with fixed-price packages
+
+**Package Examples:**
+- "AI Agent System Build: $25,000-50,000" (Claude-based autonomous agent)
+- "GoHighLevel Agency Setup: $12,000-18,000" (full CRM + automation)
+- "CRM Migration & Consolidation: $20,000-40,000" (multi-system project)
+- "Accounting Automation: $8,000-12,000" (QuickBooks + invoicing + reporting)
+
+**Benefits:**
+- Insulates from hourly-rate compression
+- Premium positioning via outcomes, not hours
+- Higher margins than time-and-materials
+
+### 4. Retainer Conversion
+
+**Strategy:** Q1 project clients are Q2 retainer candidates
+
+**Retainer Tiers:**
+- **Maintenance:** $3,000-5,000/month (monitoring, updates, support)
+- **Optimization:** $5,000-12,000/month (continuous improvement, new workflows)
+- **Strategic:** $12,000-30,000/month (consultation, training, roadmap)
+
+**April Context:** With volume contracting, retainer revenue is more valuable than ever. Q2 budget cycles will be more conservative—lock in recurring revenue.
+
+---
+
+## Platform Strategy for Q2 2026
+
+### April Landscape: All Three Declined
+
+**April Facts:**
+- Zapier: 1,785 jobs (47.0% share)—dominant via others' declines, -2.3% MoM
+- n8n: 1,252 jobs (33.0% share)—broad decline, -14.5% MoM, total flipped negative
+- Make.com: 781 jobs (20.6% share)—recovery stalled, -3.1% MoM
+- First time all three declined simultaneously since November 2025
+
+**Strategic Implications:**
+
+**Zapier Positioning:**
+- Defensive leader, gaining share through stability
+- Most accessible mid-market platform
+- Volume cushion supports specialization premiums
+- **Strategy:** Primary platform for breadth and consistency
+
+**n8n Positioning:**
+- Recovery thesis broken—total growth now negative
+- Premium niche intact for technical depth
+- Pair with CRM or industry to insulate
+- **Strategy:** Niche premium positioning, not primary-only platform
+
+**Make.com Positioning:**
+- Recovery stalled before completion
+- Still -31.7% total since May
+- Worst major-platform total decline
+- **Strategy:** Secondary platform only; reassess if May shows stabilization
+
+**Multi-Platform Approach:**
+- Volume is contracting—broader platform competence captures more bids
+- 30-40% rate premium for verified multi-platform expertise
+- Migration work between platforms remains steady
+- Platform-agnostic CRM/AI specialization travels best
+
+---
+
+## Application Strategy
+
+### Safe Bets (All Positive Since May)
+
+**1. GoHighLevel** (+22.5% since May)
+- 687 jobs—held near all-time high while market contracted -7.5%
+- Agency automation demand structurally insulated
+- Strongest signal in April's data
+- **Positioning:** Agency CRM + automation specialist
+
+**2. QuickBooks** (+31.9% since May)
+- 95 jobs—holding near 12-month high
+- Strongest total growth of any tracked application
+- Q1 accounting demand persisted into April
+- **Positioning:** Accounting automation specialist
+
+**3. HubSpot** (+13.2% since May)
+- 378 jobs—essentially flat in April (+0.8%), strong year-over-year
+- Stable strength vs market volatility
+- Certification commands premium
+- **Positioning:** Enterprise marketing automation
+
+**4. Salesforce** (+17.2% since May)
+- 102 jobs—second consecutive recovery month
+- Enterprise budget cycles favor Q2
+- Premium rates ($100-180/hr typical)
+- **Positioning:** Enterprise CRM specialist
+
+**5. Zoho** (+15.5% since May)
+- 119 jobs—total growth flipped positive
+- Volatile but trending positive
+- Asia-Pacific market opportunity
+- **Positioning:** Mid-market CRM alternative
+
+**6. Xero** (+20.0% since May)
+- 42 jobs—small but consistently growing
+- Pairs well with QuickBooks expertise
+- **Positioning:** Accounting/finance automation niche
+
+### Watch List
+
+**Monday.com** (+2.8% since May)
+- 111 jobs—remarkably stable, slight April growth
+- Most resilient alternative CRM
+- **Watch:** Continued stability through Q2
+
+**Notion** (-46.9% since May)
+- 230 jobs—April's flat reading (+0.4%) may signal floor
+- **Watch:** May data for confirmation of stabilization
+
+### Avoid/Deprioritize
+
+**Structural Decline:**
+- Excel: -52.4% total (235 jobs)—now half of May volume, worst tracked
+- ClickUp: -47.2% total (103 jobs)—accelerating decline
+- Trello: -45.3% total (41 jobs)—April bounce immaterial
+- Asana: -10.0% total (72 jobs)—April rebound but still declining year-over-year
+
+**Strategy:** Exit these specializations entirely. Focus on CRM + platform + AI/industry stacking.
+
+---
+
+## Q2 2026 Outlook
+
+### Expected May-July Trends
+
+**May 2026:**
+- Volume likely 3,500-3,800 range
+- Rates expected $38-40/hr range
+- GoHighLevel resilience continues
+- n8n trajectory needs confirmation (rebound or continued decline?)
+- Make.com recovery thesis on the line
+
+**June-July 2026:**
+- Q2 project launches may stabilize volume around 3,700-4,000
+- Rate normalization at $39-40/hr (no return to $43+ expected)
+- CRM demand remains primary growth driver
+- AI/Claude engineering tier continues to expand at the top
+
+**Q2 Bottom Line:**
+- New market reality: ~3,500-3,900 monthly jobs at $38-40/hr average
+- Premium market share around 3.5-4.0% (compression continues)
+- CRM specialization remains the safest bet
+- AI/Claude engineering replaces "AI-enhanced automation" at the premium tier
+
+---
+
+## Final Recommendations
+
+### The Premium Positioning Formula (Q2 2026)
+
+**1. CRM Foundation (Choose One):**
+- **GoHighLevel:** Held near all-time high (687 jobs), agency focus, $100-150/hr
+- **HubSpot:** Stable strength (+13.2% since May), enterprise, $90-140/hr
+- **Salesforce:** Recovery confirmed (+17.2% since May), enterprise premium, $100-180/hr
+- **QuickBooks/Xero:** Strongest total growth, accounting niche, $75-120/hr
+
+**2. Platform Proficiency:**
+- **Option A:** Zapier (defensive leader, 47.0% share, share gaining)
+- **Option B:** n8n (premium niche only; not primary-only positioning)
+- **Option C:** Both (maximum flexibility, 30-40% rate premium)
+
+**3. AI Capabilities (Now Required for Premium):**
+- Claude/OpenAI API mastery (production agents, not just chat)
+- Voice AI (Retell/Vapi)—still emerging premium
+- Document processing and intelligent extraction
+- Agent orchestration and tool use
+
+**4. Proof and Positioning:**
+- 3+ case studies with quantified ROI
+- Industry-specific portfolio
+- Active thought leadership presence
+- Value-based pricing model
+
+**Formula Result:** $100-200/hr sustainable rates, insulated from market compression
+
+### The Bottom Line
+
+April 2026 confirms what was suspected after March: the Jan-Feb rate surge was a Q1 budget event, not a structural shift.
+
+**The numbers:**
+- 14.4% fewer jobs than May baseline (worst total drawdown in tracking)
+- $39.46/hr average—back in the 2025 baseline range
+- 139 premium jobs at $75+ (3.8% share, lowest since November)
+- All three platforms declined simultaneously
+- n8n's total growth flipped negative for the first time
+- GoHighLevel and CRMs as a category held strong
+
+**Thriving Segments:**
+- AI/Claude engineering ($200-500/hr) — concentrated premium tier
+- GoHighLevel agency automation (687 jobs, held during contraction)
+- All four dedicated CRMs (first time all positive since May)
+- Accounting automation (QuickBooks +31.9% since May)
+- Industry-specific AI agent work ($150-300/hr)
+
+**Struggling Segments:**
+- Generic platform expertise (Expert tier compressed -25% MoM)
+- Single-platform positioning without CRM or AI overlay
+- Make.com-only specialization
+- Excel/ClickUp/Trello specialists
+- Sub-$50/hr positioning
+
+The market hasn't broken—it has reverted. April's contraction is a return to 2025 baseline, not a new low. For specialists with CRM + AI positioning, the opportunity remains. For generalists or those over-indexed on platform-only expertise, Q2 is going to be harder than Q1.
+
+**Less work overall. Compressed average rates. AI/Claude work as the new premium ceiling. CRM as the most resilient specialty. Q2 belongs to specialists.**
+
+---
+
+## Resources
+
+**Platform Mastery:**
+- n8n: Self-hosting guides, custom node development, Docker deployment
+- Zapier: Tables/Interfaces, advanced features, error handling
+- Make.com: Complex scenarios, error handling
+
+**AI/Claude Engineering:**
+- Anthropic Claude API documentation, tool use guide, agentic systems
+- OpenAI Cookbook (agents, function calling, structured outputs)
+- LangChain or similar for complex agent orchestration
+- Vector databases (Pinecone, Weaviate) for RAG
+
+**CRM Specialization:**
+- GoHighLevel: Certification program, community, snapshots (held near all-time high)
+- HubSpot: HubSpot Academy (free certification, stable strength)
+- Salesforce: Trailhead learning platform (recovery confirmed)
+- QuickBooks: Integration certification (strongest total growth)
+
+**Business Skills:**
+- Value-based pricing frameworks
+- Case study development
+- Retainer model design
+- AI agent thought leadership
+
+---
+
+**Report Generated:** May 2026
+**Based on:** 53,786 jobs analyzed (May 2025-April 2026)
+**High-Paying Jobs Tracked:** 139 at $75+/hr in April (3.8% of market)
+**Next Update:** May 2026 data (expected June 2026)
+
+---
+
+*Part of the Upwork Automation Market Analysis Project*
+*Tracking the evolution of automation consulting opportunities*

--- a/upwork-analysis/upwork-analysis.html
+++ b/upwork-analysis/upwork-analysis.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Upwork Automation Market Analysis: May 2025-March 2026</title>
+    <title>Upwork Automation Market Analysis: May 2025-April 2026</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.js"></script>
     <style>
         * {
@@ -334,33 +334,34 @@
 
     <main>
         <section id="overview">
-            <h1>Upwork Automation Market Analysis: May 2025-March 2026</h1>
+            <h1>Upwork Automation Market Analysis: May 2025-April 2026</h1>
 
             <div class="market-alert">
-                <h4>📈 March 2026 Market Update: Spring Bounce, All Platforms Growing</h4>
-                <p>The automation market bounced back in March 2026 to 3,939 jobs (+6.7% MoM)—the strongest monthly growth since summer 2025. All three major platforms grew simultaneously for the first time since July 2025. Rates corrected to <strong>$40.67/hr</strong> (-6.0% from February's peak) but remain the third-highest ever recorded. GoHighLevel surged to an all-time high of 693 jobs (+18.5%). n8n broke its three-month accelerating decline with +4.3% growth. Make.com posted its second consecutive positive month (+8.1%).</p>
+                <h4>📉 April 2026 Market Update: Spring Bounce Reverses, All Platforms Decline</h4>
+                <p>April 2026 reversed March's spring bounce. Volume contracted to 3,645 jobs (-7.5% MoM)—the second-lowest count in 12 months of tracking. All three major platforms shed volume: Zapier -2.3%, n8n -14.5%, Make.com -3.1%. Rates corrected to <strong>$39.46/hr</strong> (-3.0% from March), falling back below the $40 threshold. <strong>n8n's recovery undone</strong>: total growth since May flipped from +11.0% to -5.1% (first negative total in tracking). <strong>GoHighLevel held near all-time high</strong> at 687 jobs (-0.9%), demonstrating CRM resilience. High-paying jobs contracted to 139 (-16.8% MoM).</p>
             </div>
 
             <div class="executive-summary">
                 <h3>Executive Summary</h3>
-                <p>March 2026 delivered the spring bounce: volume rebounded to 3,939 jobs (+6.7% MoM, -28.7% from July peak), the strongest growth since summer 2025. Rates corrected to <strong>$40.67/hr</strong> (-6.0% from February's $43.27 peak)—still the third-highest ever, above January's $40.20. All three platforms grew for the first time since July 2025. <strong>GoHighLevel surged +18.5%</strong> to 693 jobs (all-time tracking high, +23.5% since May). <strong>n8n broke its decline</strong> at +4.3%, rebounding total growth to +11.0% since May. Generic CRM mentions hit an all-time high of 1,434 (+19.3% since May).</p>
+                <p>April 2026 confirmed the round-trip: volume back to 3,645 jobs (-7.5% MoM, -34.0% from July peak, -14.4% from May baseline). Rates fell to <strong>$39.46/hr</strong> (-3.0% from March), squarely back in the May-October $38-40 range. The Jan-Feb $40+ surge was a Q1 budget event, not a structural shift. All three platforms declined: Zapier -2.3%, n8n -14.5% (worst), Make.com -3.1%. <strong>n8n total growth flipped negative</strong> for the first time (-5.1% since May). <strong>GoHighLevel held at 687</strong> (-0.9%) demonstrating agency demand resilience. Salesforce (+15.9%) and Zoho (+17.8%) rebounded; all four dedicated CRMs are now positive since May—a first.</p>
 
                 <div class="key-insights">
-                    <h4>Critical March Developments:</h4>
+                    <h4>Critical April Developments:</h4>
                     <ul>
-                        <li><strong>Spring Bounce</strong>: 3,939 jobs (+6.7% MoM)—strongest growth since summer, all three platforms up</li>
-                        <li><strong>Rate Correction</strong>: $40.67/hr (-6.0% from Feb peak)—third-highest ever, structural floor above $40</li>
-                        <li><strong>GoHighLevel All-Time High</strong>: 693 jobs (+18.5% MoM, +23.5% since May)—dominant CRM</li>
-                        <li><strong>n8n Decline Broken</strong>: +4.3% MoM after three months of accelerating losses</li>
-                        <li><strong>Make.com Recovery Confirmed</strong>: +8.1% MoM, second consecutive positive month</li>
-                        <li><strong>CRM Demand Expanding</strong>: Generic CRM mentions at all-time high (1,434, +19.3% since May)</li>
+                        <li><strong>Spring Bounce Reversed</strong>: 3,645 jobs (-7.5% MoM)—second-lowest in tracking, all three platforms declined</li>
+                        <li><strong>Rate Reverts</strong>: $39.46/hr (-3.0% from March)—back below $40, in the 2025 baseline range</li>
+                        <li><strong>n8n Total Growth Negative</strong>: -14.5% MoM, -5.1% since May (first negative total in tracking)</li>
+                        <li><strong>GoHighLevel Resilient</strong>: 687 jobs (-0.9% MoM)—held near all-time high in a -7.5% market</li>
+                        <li><strong>CRM Rotation Continues</strong>: Salesforce +15.9%, Zoho +17.8%—all four CRMs now positive since May</li>
+                        <li><strong>High-Paying Contracted</strong>: 139 jobs at $75+ (3.8% share)—lowest count since November</li>
+                        <li><strong>AI/Claude Premium Tier</strong>: $250-500/hr work concentrated in AI agent engineering</li>
                     </ul>
                 </div>
             </div>
         </section>
 
         <section id="platform-analysis">
-            <h2>Platform Analysis: Eleven-Month Trends</h2>
+            <h2>Platform Analysis: Twelve-Month Trends</h2>
 
             <h3>Market Share & Growth Trajectory</h3>
             <table>
@@ -378,7 +379,8 @@
                         <th>January</th>
                         <th>February</th>
                         <th>March</th>
-                        <th>Feb&rarr;Mar</th>
+                        <th>April</th>
+                        <th>Mar&rarr;Apr</th>
                         <th>Total Growth</th>
                     </tr>
                 </thead>
@@ -395,9 +397,10 @@
                         <td>1,753</td>
                         <td>1,767</td>
                         <td>1,721</td>
-                        <td>1,826</td>
-                        <td class="growth-positive">+6.1%</td>
-                        <td class="growth-negative">-18.3%</td>
+                        <td>1,827</td>
+                        <td>1,785</td>
+                        <td class="growth-negative">-2.3%</td>
+                        <td class="growth-negative">-20.2%</td>
                     </tr>
                     <tr>
                         <td><strong>n8n</strong></td>
@@ -411,9 +414,10 @@
                         <td>1,663</td>
                         <td>1,535</td>
                         <td>1,403</td>
-                        <td>1,464</td>
-                        <td class="growth-positive">+4.3%</td>
-                        <td class="growth-positive">+11.0%</td>
+                        <td>1,465</td>
+                        <td>1,252</td>
+                        <td class="growth-negative">-14.5%</td>
+                        <td class="growth-negative">-5.1%</td>
                     </tr>
                     <tr>
                         <td><strong>Make.com</strong></td>
@@ -427,50 +431,51 @@
                         <td>751</td>
                         <td>725</td>
                         <td>743</td>
-                        <td>803</td>
-                        <td class="growth-positive">+8.1%</td>
-                        <td class="growth-negative">-29.7%</td>
+                        <td>806</td>
+                        <td>781</td>
+                        <td class="growth-negative">-3.1%</td>
+                        <td class="growth-negative">-31.7%</td>
                     </tr>
                 </tbody>
             </table>
 
             <div class="info-box">
                 <h4>Platform Reality Check</h4>
-                <p><strong>All three major platforms grew simultaneously</strong> for the first time since July 2025. Zapier maintained its dominant position at 1,826 jobs (46.4% share, +6.1%). n8n broke its three-month accelerating decline with +4.3% growth to 1,464 jobs, rebounding total growth since May to +11.0%. Make.com posted its second consecutive positive month at +8.1% to 803 jobs, confirming the recovery trend. The platform landscape is the healthiest it's been since summer 2025.</p>
+                <p><strong>All three major platforms declined simultaneously</strong> in April—reversing March's broad-based growth. Zapier maintained its dominant position at 1,785 jobs (46.7% share, -2.3%) but absolute volume continues to erode (-20.2% since May). n8n lost 213 jobs (-14.5% MoM, the largest single-month decline of any major platform in 2026), with total growth since May flipping negative for the first time in tracking history (-5.1%). Make.com's recovery stalled at -3.1%, ending its two-month positive streak. The platform landscape has reverted to the late-2025 baseline.</p>
             </div>
 
-            <h3>March Market Share Evolution</h3>
+            <h3>April Market Share Evolution</h3>
             <table>
                 <thead>
                     <tr>
                         <th>Platform</th>
                         <th>May Share</th>
-                        <th>February Share</th>
                         <th>March Share</th>
-                        <th>May&rarr;Mar Change</th>
+                        <th>April Share</th>
+                        <th>May&rarr;Apr Change</th>
                     </tr>
                 </thead>
                 <tbody>
                     <tr>
                         <td><strong>Zapier</strong></td>
                         <td>52.5%</td>
-                        <td>46.6%</td>
                         <td>46.4%</td>
-                        <td class="growth-negative">-6.1 pts</td>
+                        <td>46.7%</td>
+                        <td class="growth-negative">-5.8 pts</td>
                     </tr>
                     <tr>
                         <td><strong>n8n</strong></td>
                         <td>31.0%</td>
-                        <td>38.0%</td>
                         <td>37.2%</td>
-                        <td class="growth-positive">+6.2 pts</td>
+                        <td>32.8%</td>
+                        <td class="growth-positive">+1.8 pts</td>
                     </tr>
                     <tr>
                         <td><strong>Make.com</strong></td>
                         <td>26.8%</td>
-                        <td>20.1%</td>
-                        <td>20.4%</td>
-                        <td class="growth-negative">-6.4 pts</td>
+                        <td>20.5%</td>
+                        <td>20.5%</td>
+                        <td class="growth-negative">-6.3 pts</td>
                     </tr>
                 </tbody>
             </table>
@@ -491,7 +496,8 @@
                         <th>January</th>
                         <th>February</th>
                         <th>March</th>
-                        <th>11-Mo Change</th>
+                        <th>April</th>
+                        <th>12-Mo Change</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -507,8 +513,9 @@
                         <td>$37.58</td>
                         <td>$40.20</td>
                         <td>$43.27</td>
-                        <td>$40.67</td>
-                        <td class="growth-positive">+4.0%</td>
+                        <td>$40.66</td>
+                        <td>$39.46</td>
+                        <td class="growth-positive">+0.9%</td>
                     </tr>
                     <tr>
                         <td><strong>High-Paying Jobs ($75+)</strong></td>
@@ -523,7 +530,8 @@
                         <td>165</td>
                         <td>170</td>
                         <td>167</td>
-                        <td class="growth-positive">+9.2%</td>
+                        <td>139</td>
+                        <td class="growth-negative">-9.2%</td>
                     </tr>
                 </tbody>
             </table>
@@ -543,6 +551,7 @@
                         <th>Dec&rarr;Jan</th>
                         <th>Jan&rarr;Feb</th>
                         <th>Feb&rarr;Mar</th>
+                        <th>Mar&rarr;Apr</th>
                         <th>Trend</th>
                     </tr>
                 </thead>
@@ -558,8 +567,9 @@
                         <td class="growth-positive">+5.5%</td>
                         <td class="growth-positive">+0.8%</td>
                         <td class="growth-negative">-2.6%</td>
-                        <td class="growth-positive">+6.1%</td>
-                        <td>Consistent leader</td>
+                        <td class="growth-positive">+6.2%</td>
+                        <td class="growth-negative">-2.3%</td>
+                        <td>Defensive leader</td>
                     </tr>
                     <tr>
                         <td><strong>n8n</strong></td>
@@ -572,8 +582,9 @@
                         <td class="growth-negative">-3.8%</td>
                         <td class="growth-negative">-7.7%</td>
                         <td class="growth-negative">-8.6%</td>
-                        <td class="growth-positive">+4.3%</td>
-                        <td>Decline broken</td>
+                        <td class="growth-positive">+4.4%</td>
+                        <td class="growth-negative">-14.5%</td>
+                        <td>Recovery reversed</td>
                     </tr>
                     <tr>
                         <td><strong>Make.com</strong></td>
@@ -586,41 +597,42 @@
                         <td class="growth-negative">-7.4%</td>
                         <td class="growth-negative">-3.5%</td>
                         <td class="growth-positive">+2.5%</td>
-                        <td class="growth-positive">+8.1%</td>
-                        <td>Recovery confirmed</td>
+                        <td class="growth-positive">+8.5%</td>
+                        <td class="growth-negative">-3.1%</td>
+                        <td>Recovery stalled</td>
                     </tr>
                 </tbody>
             </table>
 
             <h3>Multi-Platform Opportunities</h3>
-            <p><strong>Premium work increasingly requires multiple platforms</strong>—specialists who work across n8n, Zapier, and Make.com command 35-40% rate premiums</p>
+            <p><strong>Premium work increasingly requires multiple platforms</strong>—specialists who work across n8n, Zapier, and Make.com command 30-40% rate premiums</p>
 
             <table>
                 <thead>
                     <tr>
                         <th>Metric</th>
-                        <th>December</th>
                         <th>January</th>
                         <th>February</th>
                         <th>March</th>
+                        <th>April</th>
                         <th>Trend</th>
                     </tr>
                 </thead>
                 <tbody>
                     <tr>
                         <td>Rate premium for multi-platform</td>
-                        <td>+32%</td>
                         <td>+35%</td>
                         <td>+38%</td>
                         <td>+40%</td>
-                        <td>Premium widening</td>
+                        <td>+38%</td>
+                        <td>Slight compression</td>
                     </tr>
                     <tr>
                         <td>CRM + Platform premium</td>
-                        <td>+35%</td>
                         <td>+38%</td>
                         <td>+42%</td>
                         <td>+45%</td>
+                        <td>+42%</td>
                         <td>CRM specialization critical</td>
                     </tr>
                 </tbody>
@@ -630,11 +642,11 @@
         <section id="applications">
             <h2>Application Ecosystem Evolution</h2>
 
-            <h3>Top Applications & CRM Platforms: Ten-Month Comparison</h3>
+            <h3>Top Applications & CRM Platforms: Twelve-Month Comparison</h3>
 
             <div class="update-box">
-                <h4>📊 March Application Trends</h4>
-                <p>March shows the CRM pendulum swinging back: <strong>GoHighLevel surged +18.5%</strong> to 693 jobs (all-time tracking high, +23.5% since May) and <strong>HubSpot grew +7.4%</strong> to 375 jobs (+12.3% since May). Meanwhile Salesforce corrected -20.0% and Zoho pulled back -15.8% from February's surges. Generic CRM mentions hit an all-time high at 1,434 (+19.3% since May). <strong>QuickBooks surged +28.8%</strong> to 94 jobs (+30.6% since May, strongest total growth of any application). Rates corrected to <strong>$40.67/hr</strong> (-6.0% from February's peak)—still third-highest ever.</p>
+                <h4>📊 April Application Trends</h4>
+                <p>April reversed several March trends. <strong>Salesforce rebounded +15.9%</strong> to 102 jobs and <strong>Zoho surged +17.8%</strong> to 119—both flipped to positive total growth since May for the first time. <strong>GoHighLevel held at 687 jobs</strong> (-0.9% MoM) demonstrating CRM resilience in a -7.5% market. <strong>HubSpot stable at 378</strong> (+0.8% MoM, +13.2% since May). For the first time, all four dedicated CRMs are positive since May. Notable bounces: Asana +46.9%, Trello +32.3%, Monday.com +6.7%. Excel continued declining (-6.4%, now -52.4% total). Rates fell to <strong>$39.46/hr</strong> (-3.0% from March)—back below $40.</p>
             </div>
 
             <table>
@@ -652,7 +664,8 @@
                         <th>Jan</th>
                         <th>Feb</th>
                         <th>Mar</th>
-                        <th>Feb&rarr;Mar</th>
+                        <th>Apr</th>
+                        <th>Mar&rarr;Apr</th>
                         <th>Total Change</th>
                     </tr>
                 </thead>
@@ -670,8 +683,9 @@
                         <td>645</td>
                         <td>585</td>
                         <td>693</td>
-                        <td class="growth-positive">+18.5%</td>
-                        <td class="growth-positive">+23.5%</td>
+                        <td>687</td>
+                        <td class="growth-negative">-0.9%</td>
+                        <td class="growth-positive">+22.5%</td>
                     </tr>
                     <tr>
                         <td><strong>Google Sheets</strong></td>
@@ -685,9 +699,10 @@
                         <td>552</td>
                         <td>537</td>
                         <td>495</td>
-                        <td>527</td>
-                        <td class="growth-positive">+6.5%</td>
-                        <td class="growth-negative">-33.0%</td>
+                        <td>526</td>
+                        <td>532</td>
+                        <td class="growth-positive">+1.1%</td>
+                        <td class="growth-negative">-32.3%</td>
                     </tr>
                     <tr>
                         <td><strong>Airtable</strong></td>
@@ -702,8 +717,9 @@
                         <td>467</td>
                         <td>424</td>
                         <td>435</td>
-                        <td class="growth-positive">+2.6%</td>
-                        <td class="growth-negative">-34.7%</td>
+                        <td>447</td>
+                        <td class="growth-positive">+2.8%</td>
+                        <td class="growth-negative">-32.9%</td>
                     </tr>
                     <tr>
                         <td><strong>HubSpot</strong> <em>(CRM)</em></td>
@@ -718,8 +734,9 @@
                         <td>350</td>
                         <td>349</td>
                         <td>375</td>
-                        <td class="growth-positive">+7.4%</td>
-                        <td class="growth-positive">+12.3%</td>
+                        <td>378</td>
+                        <td class="growth-positive">+0.8%</td>
+                        <td class="growth-positive">+13.2%</td>
                     </tr>
                     <tr>
                         <td><strong>Slack</strong></td>
@@ -733,9 +750,10 @@
                         <td>321</td>
                         <td>307</td>
                         <td>316</td>
-                        <td>335</td>
-                        <td class="growth-positive">+6.0%</td>
-                        <td class="growth-negative">-30.5%</td>
+                        <td>336</td>
+                        <td>323</td>
+                        <td class="growth-negative">-3.9%</td>
+                        <td class="growth-negative">-33.0%</td>
                     </tr>
                     <tr>
                         <td><strong>Excel</strong></td>
@@ -750,8 +768,9 @@
                         <td>316</td>
                         <td>280</td>
                         <td>251</td>
-                        <td class="growth-negative">-10.4%</td>
-                        <td class="growth-negative">-49.2%</td>
+                        <td>235</td>
+                        <td class="growth-negative">-6.4%</td>
+                        <td class="growth-negative">-52.4%</td>
                     </tr>
                     <tr>
                         <td><strong>Notion</strong></td>
@@ -766,8 +785,9 @@
                         <td>273</td>
                         <td>243</td>
                         <td>229</td>
-                        <td class="growth-negative">-5.8%</td>
-                        <td class="growth-negative">-47.1%</td>
+                        <td>230</td>
+                        <td class="growth-positive">+0.4%</td>
+                        <td class="growth-negative">-46.9%</td>
                     </tr>
                     <tr>
                         <td><strong>ClickUp</strong></td>
@@ -781,9 +801,10 @@
                         <td>169</td>
                         <td>146</td>
                         <td>134</td>
-                        <td>116</td>
-                        <td class="growth-negative">-13.4%</td>
-                        <td class="growth-negative">-40.5%</td>
+                        <td>112</td>
+                        <td>103</td>
+                        <td class="growth-negative">-8.0%</td>
+                        <td class="growth-negative">-47.2%</td>
                     </tr>
                     <tr>
                         <td><strong>Zoho</strong> <em>(CRM)</em></td>
@@ -798,8 +819,9 @@
                         <td>82</td>
                         <td>120</td>
                         <td>101</td>
-                        <td class="growth-negative">-15.8%</td>
-                        <td class="growth-negative">-1.9%</td>
+                        <td>119</td>
+                        <td class="growth-positive">+17.8%</td>
+                        <td class="growth-positive">+15.5%</td>
                     </tr>
                     <tr>
                         <td><strong>Salesforce</strong> <em>(CRM)</em></td>
@@ -814,8 +836,9 @@
                         <td>88</td>
                         <td>110</td>
                         <td>88</td>
-                        <td class="growth-negative">-20.0%</td>
-                        <td class="growth-positive">+1.1%</td>
+                        <td>102</td>
+                        <td class="growth-positive">+15.9%</td>
+                        <td class="growth-positive">+17.2%</td>
                     </tr>
                     <tr>
                         <td><strong>Monday.com</strong></td>
@@ -830,8 +853,9 @@
                         <td>102</td>
                         <td>101</td>
                         <td>104</td>
-                        <td class="growth-positive">+3.0%</td>
-                        <td class="growth-negative">-3.7%</td>
+                        <td>111</td>
+                        <td class="growth-positive">+6.7%</td>
+                        <td class="growth-positive">+2.8%</td>
                     </tr>
                     <tr>
                         <td><strong>Trello</strong></td>
@@ -846,8 +870,9 @@
                         <td>26</td>
                         <td>24</td>
                         <td>31</td>
-                        <td class="growth-positive">+29.2%</td>
-                        <td class="growth-negative">-58.7%</td>
+                        <td>41</td>
+                        <td class="growth-positive">+32.3%</td>
+                        <td class="growth-negative">-45.3%</td>
                     </tr>
                 </tbody>
             </table>
@@ -858,9 +883,9 @@
                     <tr>
                         <th>CRM Category</th>
                         <th>May</th>
-                        <th>February</th>
                         <th>March</th>
-                        <th>Feb&rarr;Mar</th>
+                        <th>April</th>
+                        <th>Mar&rarr;Apr</th>
                         <th>Analysis</th>
                     </tr>
                 </thead>
@@ -868,50 +893,50 @@
                     <tr>
                         <td><strong>Generic "CRM" mentions</strong></td>
                         <td>1,202</td>
-                        <td>1,241</td>
-                        <td>1,434</td>
-                        <td class="growth-positive">+15.6%</td>
-                        <td>All-time high (+19.3% since May)</td>
+                        <td>1,436</td>
+                        <td>1,379</td>
+                        <td class="growth-negative">-4.0%</td>
+                        <td>Pulled back from all-time high (+14.7% since May)</td>
                     </tr>
                     <tr>
                         <td><strong>GoHighLevel</strong></td>
                         <td>561</td>
-                        <td>585</td>
                         <td>693</td>
-                        <td class="growth-positive">+18.5%</td>
-                        <td>All-time high (+23.5% since May)</td>
+                        <td>687</td>
+                        <td class="growth-negative">-0.9%</td>
+                        <td>Held near all-time high (+22.5% since May)</td>
                     </tr>
                     <tr>
                         <td><strong>HubSpot</strong></td>
                         <td>334</td>
-                        <td>349</td>
                         <td>375</td>
-                        <td class="growth-positive">+7.4%</td>
-                        <td>Strongest since August (+12.3% since May)</td>
+                        <td>378</td>
+                        <td class="growth-positive">+0.8%</td>
+                        <td>Stable strength (+13.2% since May)</td>
                     </tr>
                     <tr>
                         <td><strong>Salesforce</strong></td>
                         <td>87</td>
-                        <td>110</td>
                         <td>88</td>
-                        <td class="growth-negative">-20.0%</td>
-                        <td>Post-surge correction (+1.1% since May)</td>
+                        <td>102</td>
+                        <td class="growth-positive">+15.9%</td>
+                        <td>Recovery confirmed (+17.2% since May)</td>
                     </tr>
                     <tr>
                         <td><strong>Zoho</strong></td>
                         <td>103</td>
-                        <td>120</td>
                         <td>101</td>
-                        <td class="growth-negative">-15.8%</td>
-                        <td>Pullback (-1.9% since May)</td>
+                        <td>119</td>
+                        <td class="growth-positive">+17.8%</td>
+                        <td>Total flipped positive (+15.5% since May)</td>
                     </tr>
                     <tr>
                         <td><strong>Alternative CRMs</strong><br><em>(Airtable, Notion, ClickUp)</em></td>
                         <td>1,294</td>
-                        <td>801</td>
+                        <td>776</td>
                         <td>780</td>
-                        <td class="growth-negative">-2.6%</td>
-                        <td>Continued decline, down -39.7% total</td>
+                        <td class="growth-positive">+0.5%</td>
+                        <td>Stabilized but down -39.7% total</td>
                     </tr>
                 </tbody>
             </table>
@@ -919,12 +944,12 @@
             <div class="key-insights">
                 <h4>Application Market Dynamics:</h4>
                 <ul>
-                    <li><strong>CRM Rotation Continues</strong>: GoHighLevel surged +18.5% to all-time high (693), HubSpot +7.4%, while Salesforce corrected -20.0% and Zoho -15.8%</li>
-                    <li><strong>CRM Demand Expanding</strong>: Generic CRM mentions at all-time high (1,434, +19.3% since May)—demand growing, not just rotating</li>
-                    <li><strong>GoHighLevel Dominates</strong>: 693 jobs is the highest single-month CRM count since tracking began</li>
-                    <li><strong>Rate Correction</strong>: $40.67/hr (-6.0% from Feb peak)—third-highest ever, structural floor above $40</li>
-                    <li><strong>Premium Stable</strong>: 167 high-paying jobs ($75+), 4.2% share—expert tier expanded to 95 jobs</li>
-                    <li><strong>QuickBooks Surges</strong>: +28.8% MoM to 94 jobs (+30.6% since May)—strongest total growth of any application</li>
+                    <li><strong>All Four CRMs Positive Since May</strong>: First time in tracking. Salesforce +17.2%, Zoho +15.5%, HubSpot +13.2%, GoHighLevel +22.5%</li>
+                    <li><strong>CRM Rotation Reverses</strong>: April's winners (Salesforce +15.9%, Zoho +17.8%) were March's losers; March's leaders pulled back slightly</li>
+                    <li><strong>GoHighLevel Resilience</strong>: Held at 687 (-0.9%) while broad market contracted -7.5%—agency demand structurally insulated</li>
+                    <li><strong>Rate Reverts</strong>: $39.46/hr (-3.0% from March)—back below $40, in 2025 baseline range</li>
+                    <li><strong>Premium Contracts</strong>: 139 high-paying jobs ($75+), 3.8% share—lowest count since November</li>
+                    <li><strong>Excel Worst Decline</strong>: -52.4% since May (235 jobs)—now half of May volume, accelerating erosion</li>
                 </ul>
             </div>
         </section>
@@ -956,7 +981,7 @@
                 </div>
 
                 <div class="chart-container">
-                    <h3>Platform Market Share (March 2026)</h3>
+                    <h3>Platform Market Share (April 2026)</h3>
                     <canvas id="marketShareChart"></canvas>
                 </div>
             </div>
@@ -965,13 +990,13 @@
         <section id="compensation">
             <h2>Compensation Analysis & Market Rates</h2>
 
-            <h3>Rate Trends: March Correction from Q1 Peak</h3>
+            <h3>Rate Trends: April Reverts Below $40</h3>
             <div class="info-box">
-                <h4>📊 Healthy Correction, Structural Floor Above $40</h4>
-                <p>March 2026 saw rates correct to <strong>$40.67/hr (-6.0% from February's $43.27 peak)</strong>—still the third-highest rate ever recorded and above January's $40.20 all-time high. The correction was expected after two months of 7%+ growth. High-paying jobs ($75+) held at 167 (4.2% share), with the expert tier ($75-100) expanding from 82 to 95 jobs. The structural shift above $40/hr appears genuine. Most realistic rates: $50-80/hr for experienced consultants, $80-250/hr for specialists.</p>
+                <h4>📊 Round-Trip Complete: Rates Return to 2025 Baseline</h4>
+                <p>April 2026 saw rates fall to <strong>$39.46/hr (-3.0% from March)</strong>—back below the $40 threshold and squarely in the May-October 2025 range. The two months at $40-43/hr (Jan-Feb) appear to have been a Q1 budget event, not a structural shift. High-paying jobs ($75+) contracted to 139 (3.8% share, lowest since November), with the expert tier ($75-100) dropping from 95 to 71 jobs. Premium positioning still works, but increasingly requires AI/Claude specialization. Most realistic rates: $50-75/hr for experienced consultants, $75-200/hr for specialists, $200-500/hr for AI agent engineering.</p>
             </div>
 
-            <h3>Realistic Rate Ranges (March 2026)</h3>
+            <h3>Realistic Rate Ranges (April 2026)</h3>
             <table>
                 <thead>
                     <tr>
@@ -1004,18 +1029,18 @@
                         <td><strong>Specialist</strong></td>
                         <td>$100-150/hr</td>
                         <td>Industry expertise + CRM + platforms</td>
-                        <td>Strong Q1 demand</td>
+                        <td>Compressed from Q1 peak</td>
                     </tr>
                     <tr>
-                        <td><strong>AI Integration Expert</strong></td>
-                        <td>$150-250/hr</td>
-                        <td>AI/LLM + automation + industry</td>
-                        <td>Premium segment booming</td>
+                        <td><strong>AI/Claude Engineer</strong></td>
+                        <td>$200-500/hr</td>
+                        <td>Production AI agents + autonomous systems</td>
+                        <td>New top tier, concentrated</td>
                     </tr>
                 </tbody>
             </table>
 
-            <h3>Rate Analysis: March Correction</h3>
+            <h3>Rate Analysis: April Round-Trip</h3>
             <table>
                 <thead>
                     <tr>
@@ -1023,6 +1048,7 @@
                         <th>May</th>
                         <th>February</th>
                         <th>March</th>
+                        <th>April</th>
                         <th>Insight</th>
                     </tr>
                 </thead>
@@ -1031,170 +1057,174 @@
                         <td><strong>Average Rate</strong></td>
                         <td>$39.10/hr</td>
                         <td>$43.27/hr</td>
-                        <td>$40.67/hr</td>
-                        <td>Corrected from peak, still third-highest ever</td>
+                        <td>$40.66/hr</td>
+                        <td>$39.46/hr</td>
+                        <td>Round-trip complete, back to 2025 baseline</td>
                     </tr>
                     <tr>
                         <td><strong>High-Paying ($75+)</strong></td>
                         <td>153 jobs</td>
                         <td>170 jobs</td>
                         <td>167 jobs</td>
-                        <td>Stable (4.2% share), expert tier expanded</td>
+                        <td>139 jobs</td>
+                        <td>Contracted (3.8% share), lowest since November</td>
                     </tr>
                     <tr>
                         <td><strong>Max Rate Observed</strong></td>
                         <td>$999/hr</td>
                         <td>$999/hr</td>
                         <td>$999/hr</td>
-                        <td>Ultra-premium consistent</td>
+                        <td>$500/hr</td>
+                        <td>Ultra-premium tier consolidated, all AI/Claude work</td>
                     </tr>
                 </tbody>
             </table>
 
-            <h3>High-Value March Insights</h3>
+            <h3>High-Value April Insights</h3>
             <div class="info-box">
-                <h4>💰 Premium Market Redistributing</h4>
-                <p>March's 167 high-paying jobs ($75+/hr) represent <strong>4.2% of total market</strong>—stable after February's 4.6% peak. Ultra-premium ($150+) contracted from 29 to 15 jobs, but the expert tier ($75-100) expanded from 82 to 95. The premium market is broadening to more accessible entry points rather than concentrating at the top. CRM specialization (GoHighLevel at all-time high, HubSpot surging), AI integration (voice agents emerging at $150-250/hr), and platform depth continue driving premium rates.</p>
+                <h4>💰 Premium Tier Consolidates Around AI Engineering</h4>
+                <p>April's 139 high-paying jobs ($75+/hr) represent <strong>3.8% of total market</strong>—lowest share since November. Ultra-premium ($150+) held at 19 jobs, but the expert tier ($75-100) compressed from 95 to 71 jobs (-25%). The top of the market is now dominated by AI/Claude engineering: $500/hr Claude AI Engineer for autonomous business agents, $300/hr n8n+OpenClaw specialist, $250/hr Claude operating system for Senior Helpers franchise. Generic platform expertise compressed; AI-native systems engineering commands the premium. CRM specialization (GoHighLevel held near all-time high) remains the most resilient mid-premium specialty.</p>
             </div>
         </section>
 
         <section id="opportunities">
-            <h2>🎯 Strategic Opportunities Guide (March 2026 Update)</h2>
+            <h2>🎯 Strategic Opportunities Guide (April 2026 Update)</h2>
 
             <div class="market-alert">
-                <h4>📈 Market Reality: Spring Bounce with All Platforms Growing</h4>
-                <p>March's +6.7% volume rebound to 3,939 jobs—the strongest growth since summer—paired with a rate correction to $40.67/hr (still third-highest ever) signals market equilibrium. All three platforms grew simultaneously for the first time since July 2025. GoHighLevel hit an all-time high of 693 jobs. n8n broke its three-month decline. Generic CRM mentions at record levels (1,434). <strong>167 high-paying jobs at 4.2% share. More opportunity, still premium rates.</strong></p>
+                <h4>📉 Market Reality: Volume Contraction, Rates Reverting</h4>
+                <p>April's -7.5% volume contraction to 3,645 jobs—second-lowest in tracking—paired with rates falling to $39.46/hr (back below $40) confirms the spring bounce was short-lived. All three platforms declined: n8n -14.5% (worst, total flipped negative), Zapier -2.3%, Make.com -3.1%. GoHighLevel held at 687 jobs (-0.9%). All four dedicated CRMs are now positive since May for the first time. <strong>139 high-paying jobs at 3.8% share. AI/Claude engineering at the new $200-500/hr ceiling.</strong></p>
             </div>
 
-            <h3>High-Value Opportunities (In Stabilized Market)</h3>
+            <h3>High-Value Opportunities (In Contracting Market)</h3>
 
-            <h4>1. GoHighLevel Agency Automation ($100-150/hr)</h4>
-            <p><strong>All-Time High:</strong> 693 jobs (+18.5% MoM, +23.5% since May)—dominant CRM by volume, agency demand at peak</p>
+            <h4>1. AI/Claude Engineering ($200-500/hr)</h4>
+            <p><strong>New Premium Ceiling:</strong> April's top rates dominated by AI agent work—$500/hr Claude AI Engineer, $300/hr n8n+OpenClaw, $250/hr Claude OS for Senior Helpers</p>
             <ul>
                 <li><strong>Why Premium:</strong>
                     <ul>
-                        <li>Highest single-month CRM count since tracking began</li>
-                        <li>Agency automation demand at peak levels</li>
-                        <li>White-label solution development valuable</li>
+                        <li>Top 10 highest-rate April jobs concentrated in AI/Claude work</li>
+                        <li>Production AI agents (tool use, memory, autonomy) command standalone premium</li>
+                        <li>Industry-vertical AI (home care, real estate, construction) at $150-300/hr</li>
+                        <li>Premium tier shifted from "AI integration" to "AI-native engineering"</li>
+                    </ul>
+                </li>
+                <li><strong>Market Position:</strong> AI agent architecture is the new top of the market</li>
+                <li><strong>Rate Range:</strong> $200-500/hr for production AI agent engineering</li>
+            </ul>
+
+            <h4>2. GoHighLevel Agency Automation ($100-150/hr)</h4>
+            <p><strong>Resilience Champion:</strong> 687 jobs (-0.9% in -7.5% market)—agency demand structurally insulated</p>
+            <ul>
+                <li><strong>Why Premium:</strong>
+                    <ul>
+                        <li>Held near all-time high while broad market contracted</li>
+                        <li>Agency automation demand structurally insulated</li>
+                        <li>White-label solution development still valuable</li>
                         <li>GoHighLevel + n8n/Zapier combinations</li>
                     </ul>
                 </li>
-                <li><strong>Market Position:</strong> Agency CRM specialization is the highest-volume opportunity</li>
+                <li><strong>Market Position:</strong> Most resilient CRM specialization in April's data</li>
                 <li><strong>Rate Range:</strong> $100-150/hr for GoHighLevel + platform expertise</li>
             </ul>
 
-            <h4>2. CRM + Automation Specialist ($75-180/hr)</h4>
-            <p><strong>Market Growth Engine:</strong> Generic CRM mentions at all-time high (1,434, +19.3% since May)—CRM demand expanding</p>
+            <h4>3. CRM + Automation Specialist ($75-200/hr)</h4>
+            <p><strong>All Four CRMs Positive Since May:</strong> First time. Salesforce +17.2%, GoHighLevel +22.5%, Zoho +15.5%, HubSpot +13.2%</p>
             <ul>
                 <li><strong>Why Premium:</strong>
                     <ul>
-                        <li>CRM demand expanding—generic mentions at record levels</li>
-                        <li>GoHighLevel +23.5%, HubSpot +12.3%, Salesforce +1.1% since May</li>
-                        <li>CRM RevOps consulting at $210/hr seen in March</li>
+                        <li>Salesforce rebounded +15.9% MoM, second consecutive recovery month</li>
+                        <li>Zoho rebounded +17.8% MoM, total flipped positive</li>
                         <li>Multi-CRM integration and migration projects valuable</li>
+                        <li>$200/hr Airtable CRM Integration role observed in April</li>
                     </ul>
                 </li>
-                <li><strong>Market Position:</strong> CRM specialization remains the single strongest positioning strategy</li>
-                <li><strong>Rate Range:</strong> $75-180/hr for CRM + platform expertise</li>
-            </ul>
-
-            <h4>3. AI Voice Agent Development ($130-250/hr)</h4>
-            <p><strong>Emerging Premium Niche:</strong> Multiple $150-250/hr roles for AI voice automation (Retell, Vapi)</p>
-            <ul>
-                <li><strong>Skills Needed:</strong>
-                    <ul>
-                        <li>Retell or Vapi platform expertise</li>
-                        <li>AI/LLM API integration</li>
-                        <li>Industry-specific voice agent design (construction, real estate, services)</li>
-                        <li>n8n or Zapier for backend integration</li>
-                    </ul>
-                </li>
-                <li><strong>Rate Premium:</strong> +50-80% for AI voice capabilities—new premium category</li>
+                <li><strong>Market Position:</strong> CRM remains the most resilient specialty in April's contracting market</li>
+                <li><strong>Rate Range:</strong> $75-200/hr for CRM + platform expertise</li>
             </ul>
 
             <h4>4. Accounting Automation ($75-120/hr)</h4>
-            <p><strong>Strongest Total Growth:</strong> QuickBooks +30.6% since May (94 jobs), Xero +22.9% (43 jobs)</p>
+            <p><strong>Strongest Total Growth Persists:</strong> QuickBooks +31.9% since May (95 jobs), Xero +20.0% (42 jobs)</p>
             <ul>
                 <li><strong>Opportunities:</strong>
                     <ul>
                         <li>QuickBooks + Zapier/Make.com integration</li>
                         <li>Xero automation workflows</li>
                         <li>Financial reporting and invoicing automation</li>
-                        <li>Tax season workflow optimization</li>
+                        <li>Multi-currency and multi-entity setups</li>
                     </ul>
                 </li>
                 <li><strong>Why Resilient:</strong> Measurable ROI, essential function, recession-resistant</li>
                 <li><strong>Rate Range:</strong> $75-120/hr for accounting automation specialists</li>
             </ul>
 
-            <h3>Platform Strategy (March Reality Check)</h3>
+            <h3>Platform Strategy (April Reality Check)</h3>
 
-            <h4>Priority 1: Zapier—Consistent Leader</h4>
+            <h4>Priority 1: Zapier—Defensive Leader</h4>
             <ul>
-                <li>Market leader with 1,826 jobs (46.4% share)—highest count since December</li>
-                <li>+6.1% MoM, consistent performance across market conditions</li>
-                <li>Broadest market, most accessible clients</li>
-                <li><strong>Action:</strong> Primary platform choice remains strongest</li>
+                <li>Market leader with 1,785 jobs (46.7% share)—gaining share through others' declines</li>
+                <li>-2.3% MoM, but most stable in absolute terms</li>
+                <li>Total -20.2% since May—worst absolute drawdown across full year</li>
+                <li><strong>Action:</strong> Primary platform; volume cushion remains, but specialization is the moat</li>
             </ul>
 
-            <h4>Priority 2: n8n—Decline Broken, Premium Intact</h4>
+            <h4>Priority 2: n8n—Recovery Failed, Premium Niche Only</h4>
             <ul>
-                <li>1,464 jobs (37.2% share), +11.0% since May (rebounded from +6.4%)</li>
-                <li>+4.3% MoM breaks three months of accelerating decline</li>
-                <li>Technical depth commands premium ($100-200/hr)</li>
-                <li><strong>Action:</strong> Premium positioning reaffirmed; confidence restored</li>
+                <li>1,252 jobs (32.8% share), now -5.1% since May (first negative total in tracking)</li>
+                <li>-14.5% MoM erases March's bounce and more</li>
+                <li>Technical depth still commands premium ($100-300/hr) for complex AI/agent work</li>
+                <li><strong>Action:</strong> Niche premium positioning only; not primary-only platform anymore</li>
             </ul>
 
-            <h4>Priority 3: CRM Specialization—Mandatory</h4>
+            <h4>Priority 3: CRM Specialization—Even More Critical</h4>
             <ul>
-                <li>GoHighLevel: +23.5% since May, all-time high at 693 jobs</li>
-                <li>HubSpot: +12.3% since May, strongest since August</li>
-                <li>Salesforce: +1.1% since May, corrected from February surge</li>
-                <li>Generic CRM: All-time high at 1,434 (+19.3% since May)</li>
-                <li><strong>Action:</strong> GoHighLevel for agencies, HubSpot for enterprise—CRM demand expanding</li>
+                <li>GoHighLevel: +22.5% since May, held near all-time high at 687 jobs</li>
+                <li>HubSpot: +13.2% since May, stable strength</li>
+                <li>Salesforce: +17.2% since May, recovery confirmed</li>
+                <li>Zoho: +15.5% since May, total flipped positive</li>
+                <li><strong>Action:</strong> All four CRMs positive—specialize in one and pair with industry vertical</li>
             </ul>
 
-            <h4>Confirmed: Make.com Recovery</h4>
+            <h4>Stalled: Make.com Recovery</h4>
             <ul>
-                <li>+8.1% MoM to 803 jobs—second consecutive positive month</li>
-                <li>Still -29.7% since May, but recovery trend confirmed</li>
-                <li><strong>Action:</strong> Viable secondary platform; reassess as primary if Q2 growth continues</li>
+                <li>-3.1% MoM to 781 jobs—ending two-month positive streak</li>
+                <li>Still -31.7% since May, worst major-platform total decline</li>
+                <li><strong>Action:</strong> Secondary platform only; recovery thesis needs Q2 confirmation</li>
             </ul>
 
-            <h3>Capitalizing on the Volume Rebound</h3>
+            <h3>Navigating the Volume Contraction</h3>
 
             <div class="action-items">
-                <h4>For All Consultants (Volume +6.7%, Rates at $40.67—Third-Highest Ever):</h4>
+                <h4>For All Consultants (Volume -7.5%, Rates Back to $39.46—2025 Baseline):</h4>
                 <ul>
-                    <li><strong>Immediately:</strong> Hold rates steady—$40.67 average supports premium pricing despite correction</li>
-                    <li><strong>Q2 Strategy:</strong> More jobs available—increase proposal volume while staying selective</li>
-                    <li><strong>Positioning:</strong> Lead with CRM expertise (GoHighLevel at all-time high, generic CRM at record)</li>
-                    <li><strong>New Opportunity:</strong> AI voice agents (Retell/Vapi) at $150-250/hr—emerging premium niche</li>
+                    <li><strong>Immediately:</strong> Hold rates steady—Q1 surge was anomaly; don't accelerate compression</li>
+                    <li><strong>Q2 Strategy:</strong> Volume contracting—proposal volume must increase; selectivity must stay</li>
+                    <li><strong>Positioning:</strong> AI/Claude engineering at the top, CRM specialization in the middle</li>
+                    <li><strong>New Premium:</strong> AI agent architecture ($200-500/hr)—the new ceiling, requires production experience</li>
                 </ul>
 
                 <h4>For Growing Consultants (Revenue Stable/Up):</h4>
                 <ul>
-                    <li>Volume rebound means more opportunity—expand selectively</li>
-                    <li>GoHighLevel at all-time high—add if not in your stack</li>
-                    <li>Explore AI voice agent development as new premium category</li>
-                    <li>Build retainer relationships with Q1 project clients</li>
+                    <li>Volume contracting means selectivity matters more—target premium tier exclusively</li>
+                    <li>Build a Claude or production AI agent demo (the new differentiator)</li>
+                    <li>Deepen CRM expertise (all four CRMs positive since May)</li>
+                    <li>Convert Q1 project clients to retainers before Q2 budget tightening</li>
                 </ul>
 
                 <h4>For Struggling Consultants (Revenue Down):</h4>
                 <ul>
-                    <li>Volume rebound creates more accessible opportunities</li>
-                    <li>Add GoHighLevel or HubSpot expertise (both surging)</li>
-                    <li>Accounting automation (QuickBooks +30.6%)—strong ROI niche</li>
-                    <li>Target $60-80/hr minimum, all three platforms growing</li>
+                    <li>Volume contraction means proposal volume must compensate—target 25+/week</li>
+                    <li>Add GoHighLevel or HubSpot expertise (both holding strong)</li>
+                    <li>Accounting automation (QuickBooks +31.9%)—most resilient ROI niche</li>
+                    <li>Target $50-75/hr range with strong specialization positioning</li>
                 </ul>
 
                 <h4>Red Flags to Avoid:</h4>
                 <ul>
-                    <li>Lowering rates because of correction—$40.67 still well above $40</li>
-                    <li>Platform-only generalist positioning without CRM focus</li>
-                    <li>Ignoring AI capabilities (voice agents emerging as premium)</li>
-                    <li>Excel, Notion, or ClickUp-only specialization (structural decline)</li>
-                    <li>Generic positioning without CRM/industry focus</li>
+                    <li>Discounting because of contraction—$39.46 is still 2025 baseline, not below</li>
+                    <li>Platform-only generalist positioning without CRM or AI focus</li>
+                    <li>Skipping AI capabilities (Claude/OpenAI agent work is the new premium)</li>
+                    <li>Excel, Notion, ClickUp, or Trello-only specialization (structural decline)</li>
+                    <li>Make.com-only positioning without secondary platform</li>
                 </ul>
             </div>
         </section>
@@ -1205,41 +1235,41 @@
             <h3>🎯 Critical Market Insights</h3>
 
             <div class="key-insights">
-                <h4>March 2026 Market Realities:</h4>
+                <h4>April 2026 Market Realities:</h4>
                 <ol>
-                    <li><strong>Spring Bounce</strong>: 3,939 jobs (+6.7% MoM, -28.7% from peak)—strongest growth since summer</li>
-                    <li><strong>Rate Correction</strong>: $40.67/hr (-6.0% from Feb)—third-highest ever, structural floor above $40</li>
-                    <li><strong>All Platforms Growing</strong>: First time since July 2025—Zapier +6.1%, n8n +4.3%, Make.com +8.1%</li>
-                    <li><strong>GoHighLevel All-Time High</strong>: 693 jobs (+18.5% MoM, +23.5% since May)—dominant CRM</li>
-                    <li><strong>n8n Decline Broken</strong>: +4.3% after three months of accelerating losses, +11.0% since May</li>
-                    <li><strong>CRM Demand Expanding</strong>: Generic CRM mentions at all-time high (1,434, +19.3% since May)</li>
-                    <li><strong>Market Equilibrium</strong>: ~3,900-4,000 jobs at $40-42/hr may be the new normal</li>
+                    <li><strong>Spring Bounce Reversed</strong>: 3,645 jobs (-7.5% MoM, -34.0% from peak)—second-lowest in tracking</li>
+                    <li><strong>Rates Reverted</strong>: $39.46/hr (-3.0% from March)—back below $40, in 2025 baseline range</li>
+                    <li><strong>All Platforms Declined</strong>: Zapier -2.3%, n8n -14.5% (worst), Make.com -3.1%</li>
+                    <li><strong>GoHighLevel Resilient</strong>: 687 jobs (-0.9% MoM)—held near all-time high in -7.5% market</li>
+                    <li><strong>n8n Total Growth Negative</strong>: -5.1% since May (first negative total in tracking)</li>
+                    <li><strong>All Four CRMs Positive Since May</strong>: First time. Salesforce +17.2%, GoHighLevel +22.5%, Zoho +15.5%, HubSpot +13.2%</li>
+                    <li><strong>New Market Range</strong>: ~3,500-3,900 jobs at $38-40/hr likely the Q2 baseline</li>
                 </ol>
             </div>
 
             <h3>📈 Q2 2026 Market Forecast</h3>
 
-            <h4>Expected Trends (April - June 2026):</h4>
+            <h4>Expected Trends (May - July 2026):</h4>
             <ul>
-                <li><strong>Volume Stabilization</strong>: Expect 3,800-4,100 range as market finds equilibrium</li>
-                <li><strong>Rate Normalization</strong>: $40-42/hr range likely sustainable, structural floor above $40</li>
-                <li><strong>GoHighLevel Momentum</strong>: All-time high suggests agency demand is structural</li>
-                <li><strong>n8n Recovery</strong>: Decline broken, needs sustained growth to confirm</li>
-                <li><strong>Make.com Trajectory</strong>: Two consecutive positive months—Q2 will confirm recovery</li>
-                <li><strong>CRM Expansion</strong>: Generic mentions at record levels—demand growing, not just rotating</li>
-                <li><strong>AI Voice Agents</strong>: Emerging premium niche may become measurable category</li>
+                <li><strong>Volume Range</strong>: Expect 3,500-3,900 range; Q1 surge has cleared</li>
+                <li><strong>Rate Normalization</strong>: $38-40/hr likely the new normal, no return to $43+</li>
+                <li><strong>GoHighLevel Resilience</strong>: April's -0.9% in -7.5% market signals structural agency demand</li>
+                <li><strong>n8n Recovery</strong>: Without May rebound, the negative-total-growth narrative hardens</li>
+                <li><strong>Make.com Trajectory</strong>: Recovery stalled; Q2 confirmation needed</li>
+                <li><strong>CRM Specialization</strong>: All four CRMs positive—safest bet for Q2</li>
+                <li><strong>AI/Claude Engineering</strong>: New premium ceiling at $200-500/hr, concentrated tier</li>
             </ul>
 
             <h3>Practical Strategies by Market Position</h3>
 
             <h4>For Struggling Consultants (Revenue Down >20%):</h4>
             <ul>
-                <li><strong>Volume Rebound Creates Opportunity:</strong>
+                <li><strong>Volume Contracting Requires Volume Strategy:</strong>
                     <ul>
-                        <li>+6.7% more jobs available—increase proposal activity</li>
-                        <li>Add GoHighLevel or HubSpot expertise (both surging)</li>
-                        <li>QuickBooks automation (+30.6% since May)—strong ROI niche</li>
-                        <li>Target $50-70/hr minimum, all platforms growing</li>
+                        <li>-7.5% fewer jobs—proposal volume must increase to 25+/week</li>
+                        <li>Add GoHighLevel or HubSpot expertise (both holding strong)</li>
+                        <li>QuickBooks automation (+31.9% since May)—strongest ROI niche</li>
+                        <li>Target $50-70/hr minimum with strong specialization positioning</li>
                     </ul>
                 </li>
             </ul>
@@ -1248,10 +1278,10 @@
             <ul>
                 <li><strong>Optimization Actions:</strong>
                     <ul>
-                        <li>Hold rates steady—$40.67 average supports premium positioning</li>
-                        <li>Add AI voice agent capabilities (emerging premium at $150-250/hr)</li>
-                        <li>Deepen CRM expertise (GoHighLevel at all-time high)</li>
-                        <li>Build retainer relationships with Q1 project clients</li>
+                        <li>Hold rates steady—don't accelerate compression by discounting</li>
+                        <li>Build a production AI agent demo (Claude/OpenAI tool use)</li>
+                        <li>Deepen CRM expertise (all four CRMs positive since May)</li>
+                        <li>Convert Q1 project clients to retainers before Q2 budget tightening</li>
                     </ul>
                 </li>
             </ul>
@@ -1260,10 +1290,10 @@
             <ul>
                 <li><strong>Scale Actions:</strong>
                     <ul>
-                        <li>Explore AI voice agent development as new premium tier</li>
-                        <li>Expand CRM consulting (RevOps at $210/hr seen in March)</li>
-                        <li>Capitalize on volume rebound—selectively scale delivery</li>
-                        <li>Build team to handle growing opportunity set</li>
+                        <li>Reposition around AI agent architecture ($200-500/hr—the new ceiling)</li>
+                        <li>Industry-vertical AI work (home care, real estate, construction) at $150-300/hr</li>
+                        <li>Selectively expand into highest-margin niches</li>
+                        <li>Build team to handle premium AI engineering work</li>
                     </ul>
                 </li>
             </ul>
@@ -1273,60 +1303,60 @@
             <div class="action-items">
                 <h4>Non-Negotiable Capabilities:</h4>
                 <ol>
-                    <li><strong>CRM Specialization</strong>: GoHighLevel (all-time high), HubSpot (surging +12.3%), or Salesforce expertise</li>
-                    <li><strong>Platform Proficiency</strong>: Zapier (consistent leader) or n8n (decline broken, premium intact)</li>
-                    <li><strong>AI Integration</strong>: OpenAI/Anthropic APIs + emerging voice AI (Retell/Vapi)</li>
+                    <li><strong>CRM Specialization</strong>: GoHighLevel (resilient), HubSpot (stable), Salesforce (recovering), or Zoho (rebounded)</li>
+                    <li><strong>Platform Proficiency</strong>: Zapier (defensive leader) — n8n only as premium niche</li>
+                    <li><strong>AI/Claude Engineering</strong>: Production agents (tool use, memory) — the new premium ceiling</li>
                     <li><strong>Value Positioning</strong>: Outcome-based pricing, not hourly competition</li>
                     <li><strong>Industry Focus</strong>: Deep knowledge in 1-2 verticals</li>
                 </ol>
 
                 <h4>Recommended Learning Path (Next 90 Days):</h4>
                 <ol>
-                    <li><strong>Week 1-2:</strong> GoHighLevel, HubSpot, or Salesforce deep-dive</li>
-                    <li><strong>Week 3-4:</strong> Zapier advanced features or n8n self-hosting</li>
-                    <li><strong>Week 5-6:</strong> AI voice agents (Retell/Vapi) + OpenAI API</li>
+                    <li><strong>Week 1-2:</strong> GoHighLevel, HubSpot, Salesforce, or Zoho deep-dive</li>
+                    <li><strong>Week 3-4:</strong> Zapier advanced features (Tables, Interfaces)</li>
+                    <li><strong>Week 5-6:</strong> Claude or OpenAI agent engineering (production tool use, memory)</li>
                     <li><strong>Week 7-8:</strong> QuickBooks/Xero accounting automation</li>
-                    <li><strong>Week 9-12:</strong> Industry vertical positioning (agency, construction, accounting)</li>
+                    <li><strong>Week 9-12:</strong> Industry vertical positioning + production AI agent portfolio</li>
                 </ol>
             </div>
 
-            <h3>Final Recommendations: Market Equilibrium</h3>
+            <h3>Final Recommendations: Round-Trip Complete</h3>
 
             <div class="executive-summary">
                 <h4>The Bottom Line:</h4>
-                <p>March 2026 signals market equilibrium: 3,939 monthly jobs (+6.7%) at $40.67/hr (third-highest ever) with 167 premium opportunities at $75+/hr. <strong>The market bounced back with all platforms growing simultaneously for the first time since July 2025.</strong> Success strategies for Q2 2026:</p>
+                <p>April 2026 confirms what March hinted at: the Jan-Feb $40+ surge was a Q1 budget event, not a structural shift. April's 3,645 monthly jobs (-7.5%) at $39.46/hr (back below $40) with 139 premium opportunities at $75+/hr complete the round-trip to 2025 baseline. <strong>n8n's total growth flipped negative for the first time. GoHighLevel held near all-time high. AI/Claude engineering replaced "AI integration" at the premium ceiling.</strong> Success strategies for Q2 2026:</p>
                 <ol>
-                    <li><strong>CRM First</strong>: GoHighLevel at all-time high (+23.5%), HubSpot surging (+12.3%), generic CRM at record levels</li>
-                    <li><strong>Platform Foundation</strong>: Zapier (46.4% share, consistent) or n8n (decline broken, +11.0% since May)</li>
-                    <li><strong>Premium Positioning</strong>: Target $75-150/hr, $40.67 average supports it, 4.2% premium share</li>
-                    <li><strong>AI Voice Agents</strong>: Emerging premium niche at $150-250/hr (Retell/Vapi)</li>
-                    <li><strong>Accounting Niche</strong>: QuickBooks (+30.6%) and Xero (+22.9%)—strongest total growth</li>
-                    <li><strong>Hold Rates</strong>: Correction from $43.27 to $40.67 is normalization, not downturn</li>
+                    <li><strong>CRM First</strong>: All four dedicated CRMs now positive since May (first time)—pick one, pair with industry</li>
+                    <li><strong>Platform Foundation</strong>: Zapier (46.7% share, defensive leader) — n8n only as premium niche specialist</li>
+                    <li><strong>Premium Positioning</strong>: Target $75-150/hr; expert tier compressed but still viable</li>
+                    <li><strong>AI/Claude Engineering</strong>: New premium ceiling at $200-500/hr (production agents, autonomous systems)</li>
+                    <li><strong>Accounting Niche</strong>: QuickBooks (+31.9%) and Xero (+20.0%)—most resilient ROI work</li>
+                    <li><strong>Hold Rates</strong>: $39.46 is 2025 baseline—don't accelerate compression by discounting</li>
                 </ol>
-                <p><strong>The market is finding equilibrium.</strong> ~3,900-4,000 jobs at $40-42/hr with all platforms growing. CRM demand at record levels. GoHighLevel at all-time high. n8n's decline broken. Make.com recovery confirmed. More jobs available, still premium rates. Q2 is wide open for specialists positioned with CRM + platform + AI expertise.</p>
+                <p><strong>The market round-trip is complete.</strong> ~3,500-3,900 jobs at $38-40/hr is the Q2 baseline. CRM demand structurally resilient (all four positive). GoHighLevel held during contraction. n8n's recovery undone. Make.com recovery stalled. AI/Claude engineering is the new premium ceiling. Q2 belongs to specialists with CRM + AI/Claude positioning.</p>
             </div>
 
             <div class="market-alert">
-                <h4>📊 Key Takeaways from March 2026</h4>
+                <h4>📊 Key Takeaways from April 2026</h4>
                 <ul>
-                    <li>📈 <strong>Spring bounce</strong>: 3,939 jobs (+6.7% MoM)—strongest growth since summer, all three platforms up</li>
-                    <li>📊 <strong>Rate correction</strong>: $40.67/hr (-6.0% from Feb peak)—third-highest ever, floor above $40</li>
-                    <li>✅ <strong>GoHighLevel all-time high</strong>: 693 jobs (+18.5% MoM, +23.5% since May)—dominant CRM</li>
-                    <li>✅ <strong>n8n decline broken</strong>: +4.3% MoM, total growth rebounds to +11.0% since May</li>
-                    <li>✅ <strong>Make.com recovery confirmed</strong>: +8.1% MoM, second consecutive positive month</li>
-                    <li>✅ <strong>CRM demand expanding</strong>: Generic mentions at all-time high (1,434, +19.3% since May)</li>
-                    <li>🟢 <strong>Premium stable</strong>: 167 jobs at $75+ (4.2% share), expert tier expanded</li>
-                    <li>🚀 <strong>QuickBooks strongest growth</strong>: +30.6% since May—top application by total growth</li>
+                    <li>📉 <strong>Spring bounce reversed</strong>: 3,645 jobs (-7.5% MoM)—second-lowest in tracking, all three platforms declined</li>
+                    <li>📊 <strong>Rates reverted</strong>: $39.46/hr (-3.0% from March)—back below $40, in 2025 baseline range</li>
+                    <li>⚠️ <strong>n8n total growth negative</strong>: -5.1% since May (first negative total in tracking history)</li>
+                    <li>✅ <strong>GoHighLevel resilient</strong>: 687 jobs (-0.9%)—held near all-time high in -7.5% market</li>
+                    <li>✅ <strong>All four CRMs positive since May</strong>: First time. Salesforce +17.2%, Zoho +15.5%, HubSpot +13.2%, GoHighLevel +22.5%</li>
+                    <li>🚀 <strong>AI/Claude engineering premium</strong>: $200-500/hr work concentrated at the top tier</li>
+                    <li>📉 <strong>Premium contracted</strong>: 139 jobs at $75+ (3.8% share)—lowest count since November</li>
+                    <li>📉 <strong>Excel worst decline</strong>: -52.4% since May—now half of May volume</li>
                 </ul>
-                <p>The market bounced back. All platforms growing. CRM demand at record levels. Rates above $40. GoHighLevel at all-time high. n8n's trajectory reversed. More opportunity, still premium rates. The specialist economy continues—with more jobs available than at any point since January.</p>
+                <p>The market round-trip is complete. All three platforms declined. The Q1 rate surge was an anomaly, not a new floor. CRM specialization remains the most resilient bet—all four CRMs now positive since May for the first time. AI/Claude engineering replaces "AI integration" at the premium ceiling. The specialist economy continues, but Q2 demands sharper positioning than Q1.</p>
             </div>
         </section>
     </main>
 
     <footer>
-        <p>Upwork Automation Market Analysis • May 2025-March 2026 • Based on 50,141 job postings</p>
+        <p>Upwork Automation Market Analysis • May 2025-April 2026 • Based on 53,786 job postings</p>
         <p>Data analysis performed using comprehensive CSV exports from Upwork automation job listings</p>
-        <p>Next update: April 2026 data to track continued market evolution</p>
+        <p>Next update: May 2026 data to track continued market evolution</p>
     </footer>
 
     <script>
@@ -1360,24 +1390,24 @@
         new Chart(platformGrowthCtx, {
             type: 'line',
             data: {
-                labels: ['May 2025', 'June 2025', 'July 2025', 'August 2025', 'September 2025', 'October 2025', 'November 2025', 'December 2025', 'January 2026', 'February 2026', 'March 2026'],
+                labels: ['May 2025', 'June 2025', 'July 2025', 'August 2025', 'September 2025', 'October 2025', 'November 2025', 'December 2025', 'January 2026', 'February 2026', 'March 2026', 'April 2026'],
                 datasets: [{
                     label: 'Zapier',
-                    data: [2236, 2554, 2796, 2663, 2233, 2132, 1662, 1753, 1767, 1721, 1826],
+                    data: [2236, 2554, 2796, 2663, 2233, 2132, 1662, 1753, 1767, 1721, 1827, 1785],
                     borderColor: '#FF6B6B',
                     backgroundColor: 'rgba(255, 107, 107, 0.1)',
                     tension: 0.4,
                     borderWidth: 3
                 }, {
                     label: 'n8n',
-                    data: [1319, 1794, 1984, 2155, 2099, 2024, 1729, 1663, 1535, 1403, 1464],
+                    data: [1319, 1794, 1984, 2155, 2099, 2024, 1729, 1663, 1535, 1403, 1465, 1252],
                     borderColor: '#4ECDC4',
                     backgroundColor: 'rgba(78, 205, 196, 0.1)',
                     tension: 0.4,
                     borderWidth: 3
                 }, {
                     label: 'Make.com',
-                    data: [1143, 1278, 1429, 1174, 967, 1027, 811, 751, 725, 743, 803],
+                    data: [1143, 1278, 1429, 1174, 967, 1027, 811, 751, 725, 743, 806, 781],
                     borderColor: '#45B7D1',
                     backgroundColor: 'rgba(69, 183, 209, 0.1)',
                     tension: 0.4,
@@ -1392,7 +1422,7 @@
                     },
                     title: {
                         display: true,
-                        text: 'Platform Job Trajectory (May 2025-March 2026) - All Platforms Growing'
+                        text: 'Platform Job Trajectory (May 2025-April 2026) - All Three Declined in April'
                     }
                 },
                 scales: {
@@ -1413,11 +1443,11 @@
         new Chart(marketVolumeCtx, {
             type: 'bar',
             data: {
-                labels: ['May 2025', 'June 2025', 'July 2025', 'August 2025', 'September 2025', 'October 2025', 'November 2025', 'December 2025', 'January 2026', 'February 2026', 'March 2026'],
+                labels: ['May 2025', 'June 2025', 'July 2025', 'August 2025', 'September 2025', 'October 2025', 'November 2025', 'December 2025', 'January 2026', 'February 2026', 'March 2026', 'April 2026'],
                 datasets: [{
                     label: 'Total Jobs',
-                    data: [4256, 5143, 5522, 5402, 5072, 5031, 4203, 3938, 3945, 3690, 3939],
-                    backgroundColor: ['#95E1D3', '#81C7BA', '#6DADA1', '#FFA07A', '#FF6B6B', '#FF9999', '#CC4444', '#AA3333', '#88AA44', '#CC3333', '#88BB55'],
+                    data: [4256, 5143, 5522, 5402, 5072, 5031, 4203, 3938, 3945, 3690, 3940, 3645],
+                    backgroundColor: ['#95E1D3', '#81C7BA', '#6DADA1', '#FFA07A', '#FF6B6B', '#FF9999', '#CC4444', '#AA3333', '#88AA44', '#CC3333', '#88BB55', '#CC4444'],
                     borderRadius: 8
                 }]
             },
@@ -1427,7 +1457,7 @@
                     legend: { display: false },
                     title: {
                         display: true,
-                        text: 'Overall Market Volume (March Spring Bounce)'
+                        text: 'Overall Market Volume (April Reverses Spring Bounce)'
                     }
                 },
                 scales: {
@@ -1448,31 +1478,31 @@
         new Chart(appEvolutionCtx, {
             type: 'line',
             data: {
-                labels: ['May', 'June', 'July', 'August', 'September', 'October', 'November', 'December', 'January', 'February', 'March'],
+                labels: ['May', 'June', 'July', 'August', 'September', 'October', 'November', 'December', 'January', 'February', 'March', 'April'],
                 datasets: [{
                     label: 'GoHighLevel',
-                    data: [561, 647, 682, 647, 662, 659, 579, 562, 645, 585, 693],
+                    data: [561, 647, 682, 647, 662, 659, 579, 562, 645, 585, 693, 687],
                     borderColor: '#4ECDC4',
                     borderWidth: 3,
                     tension: 0.4
                 }, {
                     label: 'HubSpot',
-                    data: [334, 396, 412, 490, 450, 447, 346, 333, 350, 349, 375],
+                    data: [334, 396, 412, 490, 450, 447, 346, 333, 350, 349, 375, 378],
                     borderColor: '#FF6B6B',
                     tension: 0.4
                 }, {
                     label: 'Airtable',
-                    data: [666, 779, 916, 731, 604, 611, 505, 492, 467, 424, 435],
+                    data: [666, 779, 916, 731, 604, 611, 505, 492, 467, 424, 435, 447],
                     borderColor: '#45B7D1',
                     tension: 0.4
                 }, {
                     label: 'Zoho',
-                    data: [103, 113, 175, 163, 124, 141, 128, 122, 82, 120, 101],
+                    data: [103, 113, 175, 163, 124, 141, 128, 122, 82, 120, 101, 119],
                     borderColor: '#95E1D3',
                     tension: 0.4
                 }, {
                     label: 'Slack',
-                    data: [482, 485, 625, 519, 460, 461, 354, 321, 307, 316, 335],
+                    data: [482, 485, 625, 519, 460, 461, 354, 321, 307, 316, 336, 323],
                     borderColor: '#F38181',
                     tension: 0.4
                 }]
@@ -1482,7 +1512,7 @@
                 plugins: {
                     title: {
                         display: true,
-                        text: 'Key Application Trends (May 2025-March 2026) - GoHighLevel All-Time High'
+                        text: 'Key Application Trends (May 2025-April 2026) - GoHighLevel Holds Near All-Time High'
                     },
                     legend: {
                         position: 'bottom'
@@ -1501,10 +1531,10 @@
         new Chart(rateEvolutionCtx, {
             type: 'line',
             data: {
-                labels: ['May 2025', 'June 2025', 'July 2025', 'August 2025', 'September 2025', 'October 2025', 'November 2025', 'December 2025', 'January 2026', 'February 2026', 'March 2026'],
+                labels: ['May 2025', 'June 2025', 'July 2025', 'August 2025', 'September 2025', 'October 2025', 'November 2025', 'December 2025', 'January 2026', 'February 2026', 'March 2026', 'April 2026'],
                 datasets: [{
                     label: 'Market Average',
-                    data: [39.10, 39.35, 39.61, 39.07, 38.74, 38.17, 38.79, 37.58, 40.20, 43.27, 40.67],
+                    data: [39.10, 39.35, 39.61, 39.07, 38.74, 38.17, 38.79, 37.58, 40.20, 43.27, 40.66, 39.46],
                     borderColor: '#FF6B6B',
                     backgroundColor: '#FF6B6B',
                     tension: 0.1,
@@ -1519,7 +1549,7 @@
                     },
                     title: {
                         display: true,
-                        text: 'Average Hourly Rate Evolution (Correction from Q1 Peak, Floor Above $40)'
+                        text: 'Average Hourly Rate Evolution (April Reverts Below $40)'
                     }
                 },
                 scales: {
@@ -1535,14 +1565,14 @@
             }
         });
 
-        // Market Share Chart (February)
+        // Market Share Chart (April)
         const marketShareCtx = document.getElementById('marketShareChart').getContext('2d');
         new Chart(marketShareCtx, {
             type: 'doughnut',
             data: {
-                labels: ['Zapier (46.4%)', 'n8n (37.2%)', 'Make.com (20.4%)'],
+                labels: ['Zapier (46.7%)', 'n8n (32.8%)', 'Make.com (20.5%)'],
                 datasets: [{
-                    data: [1826, 1464, 803],
+                    data: [1785, 1252, 781],
                     backgroundColor: ['#FF6B6B', '#4ECDC4', '#45B7D1'],
                     borderWidth: 2,
                     borderColor: '#fff'
@@ -1561,7 +1591,7 @@
                     },
                     title: {
                         display: true,
-                        text: 'Platform Market Share - March 2026 (Zapier Leads at 46.4%)'
+                        text: 'Platform Market Share - April 2026 (Zapier Gains via Others\' Decline)'
                     }
                 }
             }


### PR DESCRIPTION
## [0.12.0] - 2026-05-01
### Added
- upwork-analysis/app-comparison-april-2026.md
- upwork-analysis/high-paying-guide-april-2026.md
- upwork_export_filtered_2026-04.csv
- APRIL_2026_SKOOL_POST.md (Skool.com community post)
### Changed
- upwork-analysis/upwork-analysis.html: Updated to include April 2026 data (May 2025-April 2026, 12-month analysis, 53,786 total jobs)
- analyze_upwork_data.py: Updated months list to include all 12 months with current naming convention (`upwork_export_filtered_YYYY-MM.csv`)
### Key Findings
- Spring bounce reversed: 3,645 jobs (-7.5% MoM)—second-lowest in tracking, all three platforms declined
- Rates reverted: $39.46/hr (-3.0% from March)—back below $40, 12-month round-trip complete
- n8n total growth flipped negative: -14.5% MoM, -5.1% since May (first negative total in tracking history)
- GoHighLevel resilient: 687 jobs (-0.9% MoM)—held near all-time high in -7.5% market
- All four dedicated CRMs positive since May: First time. Salesforce +17.2%, GoHighLevel +22.5%, Zoho +15.5%, HubSpot +13.2%
- Salesforce recovery confirmed: +15.9% MoM, second consecutive recovery month
- Zoho rebound: +17.8% MoM, total flipped positive (+15.5% since May)
- Make.com recovery stalled: -3.1% MoM, ending two-month positive streak
- AI/Claude engineering as new premium ceiling: $200-500/hr work concentrated at the top tier
- Premium tier contracted: 139 jobs at $75+ (3.8% share)—lowest count since November, expert tier -25%
- Excel worst total decline: -52.4% since May—now half of May volume
